### PR TITLE
Include long commit messages in uploaded patches.

### DIFF
--- a/git-bz
+++ b/git-bz
@@ -1767,6 +1767,9 @@ def attach_commits(bug, commits, include_comments=True, edit_comments=False, sta
             obsoletes = []
             review = []
             superreview = []
+        # Prepend the body
+        if body:
+            patch = body + "\n\n" + patch
         # Prepend the commit message
         if commit_message:
             patch = commit_message + "\n\n" + patch


### PR DESCRIPTION
...omment.

This makes long/informative patch descriptions show up in the overview page when
doing a splinter review, which is a good thing.
