### PR TITLE
Use env in interpreter shebang.

### DIFF
--- a/git-bz
+++ b/git-bz
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # git-bz - git subcommand to integrate with bugzilla
 #


### PR DESCRIPTION
Ensures that this will work on systems where Python doesn't necessarily reside in /usr/bin.
