### PR TITLE
add browser 'manual' with manually specified cookies

### DIFF
--- a/git-bz
+++ b/git-bz
@@ -686,11 +686,23 @@ def get_bugzilla_cookies_google_chrome(host):
                                     "Google Chrome",
                                     '~/.config/google-chrome/Default')
 
+def get_bugzilla_cookies_manual(host):
+    tracker = get_tracker()
+    config = get_config(tracker)
+    for p in 'bugzilla-login', 'bugzilla-logincookie':
+        if p not in config:
+            raise CookieError("config `bz-tracker.%s.%s` not found" % (tracker, p))
+    return {
+        'Bugzilla_login': config['bugzilla-login'],
+        'Bugzilla_logincookie': config['bugzilla-logincookie'],
+    }
+
 browsers = { 'firefox3'     : get_bugzilla_cookies_ff3,
              'epiphany'     : get_bugzilla_cookies_epy,
              'galeon'       : get_bugzilla_cookies_galeon,
              'chromium'     : get_bugzilla_cookies_chromium,
-             'google-chrome': get_bugzilla_cookies_google_chrome }
+             'google-chrome': get_bugzilla_cookies_google_chrome,
+             'manual'       : get_bugzilla_cookies_manual }
 
 def browser_list():
     return ", ".join(sorted(browsers.keys()))

--- a/git-bz.txt
+++ b/git-bz.txt
@@ -263,13 +263,22 @@ AUTHENTICATION
 --------------
 In order to use git-bz you need to already be logged into the bug tracker
 in your web browser, and git-bz reads your browser cookie. Currently only
-Firefox 3, Epiphany and Galeon are supported, and only on Linux. Patches to
-add more support and to allow configuring username/password directly
-per bug tracker accepted.
+Firefox 3, Epiphany and Galeon are supported, and only on Linux.
 
 By default, when using Firefox profiles, git-bz will use your the default
 profile specified in profiles.ini. You may override this using the config
 variable +bz.firefox-profile+.
+
+If you don't run a browser on the machine where you use git-bz, you can set
++bz.browser+ to +manual+, and add per-tracker configuration with cookies
+extracted from your Firefox configuration.  Note that you'll need to change
+these when/if the cookies become invalid.  For example:
+
+----------------------------------------
+git config bz.browser manual
+git config bz.bugzilla.gnome.org.bugzilla-login 9999
+git config bz.bugzilla.gnome.org.bugzilla-logincookie ABCD1234ABCD1234
+----------------------------------------
 
 BUG REFERENCES
 --------------


### PR DESCRIPTION
This allows me to use `git bz` on my server, albiet with a little manual fiddling around to find the cookies.  The cookies expire in 2037, so I assume they're reasonably long-term..
