### PR TITLE
Strip off leading commas for attachments

### DIFF
--- a/git-bz
+++ b/git-bz
@@ -1708,7 +1708,7 @@ def do_apply(bug_reference):
 
 def strip_bug_prefix(bug, description):
     # Strip any Bug XXXXXX prefix in a short description
-    pattern = r"^\s*[Bb](ug)?\s*=?\s*%s\s*[\-:]?\s*" % (bug.id)
+    pattern = r"^\s*[Bb](ug)?\s*=?\s*%s\s*[\-:,]?\s*" % (bug.id)
     return re.sub(pattern, "", description)
 
 def strip_bug_url(bug, commit_body):


### PR DESCRIPTION
With a patch description like
Bug 12354, part 1 - Foo
The current behavior is that it gets turned into
, part 1 - Foo
when being turned into a bugzilla description.
With this mighty patch, it will instead be turned into
part 1 - Foo
