### PR TITLE
add missing whitespace option to |git bz file|

### DIFF
--- a/git-bz
+++ b/git-bz
@@ -2515,6 +2515,7 @@ elif command == 'file':
     parser.set_usage("git bz file [options] [[<product>]]/<component>] (<commit> | <revision range>)");
     add_add_url_options()
     add_edit_option()
+    add_whitespace_option()
     min_args = 1
     max_args = 2
 elif command == 'push':


### PR DESCRIPTION
Pull request #17 added a -w option, but failed to add the appropriate
option to the |git bz file| command.  |git bz file| fails without this
option, as other code complains about the unknown `ignore_all_spaces'
option.
