### PR TITLE
Add an option to bypass checking for remote commits in add-url

### DIFF
--- a/git-bz
+++ b/git-bz
@@ -299,6 +299,12 @@ def get_add_url_method():
     except CalledProcessError:
         return "body-append:%u"
 
+def get_add_url_ignore_remote_commits():
+    try:
+        return git.config('bz.add-url-ignore-remote-commits', get=True) == 'true'
+    except CalledProcessError:
+        return False
+
 def get_firefox_profile_pref():
     try:
         return git.config('bz.firefox-profile', get=True)
@@ -1501,17 +1507,18 @@ def check_add_url(commits, bug_id=None, is_add_url=False):
         if base != commit.id:
             die("%s %s\nNot an ancestor of HEAD, can't add bug URL to it" % (commit.id[0:7], commit.subject))
 
-        # see if the commit is present in any remote branches
-        remote_branches = git.branch(contains=commit.id, r=True)
-        if remote_branches != "":
-            print commit.id[0:7], commit.subject
-            print "Commit is already in remote branch(es):", " ".join(remote_branches.split())
-            if not prompt("Rewrite the commit add the bug URL anyways?"):
-                if is_add_url:
-                    print "Aborting."
-                else:
-                    print "Aborting. You can use -n/--no-add-url to turn off adding the URL"
-                sys.exit(0)
+        if not get_add_url_ignore_remote_commits():
+            # see if the commit is present in any remote branches
+            remote_branches = git.branch(contains=commit.id, r=True)
+            if remote_branches != "":
+                print commit.id[0:7], commit.subject
+                print "Commit is already in remote branch(es):", " ".join(remote_branches.split())
+                if not prompt("Rewrite the commit add the bug URL anyways?"):
+                    if is_add_url:
+                        print "Aborting."
+                    else:
+                        print "Aborting. You can use -n/--no-add-url to turn off adding the URL"
+                    sys.exit(0)
 
     # Check for merge commits
     oldest_commit = commits[-1]

--- a/git-bz.txt
+++ b/git-bz.txt
@@ -333,6 +333,14 @@ If you want to disable adding URLs by default, you can use the +bz.add-url+
 config variable, which defaults to false. The -u/--add-url and -n/--no-add-url
 command line options override the config variable.
 
+[[add-url-ignore-remote-commits]]
+ADD URL IGNORE REMOTE COMMITS
+-----------------------------
+By default, when adding a URL to your commits, git-bz checks to make sure
+that the commits in question are not published to a remote.  This can be
+very slow, and you can disable this check if you don't need it by setting
+the git config variable +bz.add-url-ignore-remote-commits+ to true.
+
 FLAGS
 -----
 You can set flags on attachments by editing the submission (+-e+).  The


### PR DESCRIPTION
git branch --contains -r is extremely slow, so by default things such as
filing a bug with an attachment while using the add-url option can be
very slow.  This patch adds a config variable for making things faster
by skipping this check.

r? @froydnj or @amccreight.