### PR TITLE
Add newline to the patch when uploading

### DIFF
--- a/git-bz
+++ b/git-bz
@@ -1901,7 +1901,7 @@ def attach_commits(bug, commits, fill_comment=True, edit=False, status='none'):
         # Prepend the author information in HG patch format.
         hgstring = '# HG changeset patch\n'
         hgstring += "# User " + commit_range.author + '\n\n'
-        patch = hgstring + patch
+        patch = hgstring + patch + '\n'
 
         bug.create_patch(description, comment, filename, patch, obsoletes=obsoletes, status=status, review=review, superreview=superreview, feedback=feedback, ui_review=ui_review)
 


### PR DESCRIPTION
My patch upload by 'git bz attach' often cannot be applied by 'git bz
apply'. The reason is that the patch being corrupt at the end of the
file. Adding a blank line at the patch will fix this issue.