### PR TITLE
Save the last git-bz file instead of deleting it

### DIFF
--- a/git-bz
+++ b/git-bz
@@ -841,7 +841,13 @@ def edit_template(template):
     lines = filter(lambda x: not x.startswith("#"), f.readlines())
     f.close()
 
-    os.remove(filename)
+    # Save the last file in a known location in case we fail to attach the
+    # patch for some reason.
+    tmpdir = tempfile.gettempdir()
+    target = os.path.join(tmpdir, "git-bz-last.txt")
+    if os.path.exists(target):
+        os.remove(target)
+    os.rename(filename, target)
 
     return lines
 


### PR DESCRIPTION
There's have been a few times recently where I've been trying to attach a file
using 'git bz attach -e' where the upload will fail for one reason or another
(most often to do with entering the reviewer's email wrong). In some cases,
I'll have entered a long comment about my patch, which will be lost forever.

This patch saves the last file in $TMPDIR/git-bz-last.txt (I hope in a
platform-agnostic manner) so that it can be recovered if needed.