### PR TITLE
REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@ git-bz-moz
 
 A fork of the git-bz tool with a few tweaks specific to bugzilla.mozilla.org, and other fixes not upstreamed.
 
+To authenticate, you need to specify your bugzilla user name and API key.
+
+You can set your bugzilla user name by running:
+  git config --global bz.username <your username>
+
+An API key can be obtained here:
+  https://bugzilla.mozilla.org/userprefs.cgi?tab=apikey
+Once obtained, set the API key by running:
+  git config --global bz.apikey <your bugzilla API key>
+
 Some code is imported from the Mozilla version-control-tools repository, revision 35edcee4c73415fa45ff95ed07bb8129d41821f9
 The repository is located at https://hg.mozilla.org/hgcustom/version-control-tools/
   - auth.py is copied from pylib/mozhg/mozhg/

--- a/README.md
+++ b/README.md
@@ -2,3 +2,9 @@ git-bz-moz
 ==========
 
 A fork of the git-bz tool with a few tweaks specific to bugzilla.mozilla.org, and other fixes not upstreamed.
+
+Some code is imported from the Mozilla version-control-tools repository, revision 35edcee4c73415fa45ff95ed07bb8129d41821f9
+The repository is located at https://hg.mozilla.org/hgcustom/version-control-tools/
+  - auth.py is copied from pylib/mozhg/mozhg/
+  - bz.py and bzauth.py are copied from hgext/bzexport/
+  - bzexport.py is a few pieces of code copied from hgext/bzexport/__init__.py

--- a/bz.py
+++ b/bz.py
@@ -1,0 +1,149 @@
+# Copyright (C) 2010 Mozilla Foundation
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import base64
+import urllib
+import urllib2
+import urlparse
+
+JSON_HEADERS = {"Accept": "application/json",
+                "Content-Type": "application/json"}
+
+
+def make_url(api_server, auth, command, args={}):
+    url = urlparse.urljoin(api_server, command)
+    if auth is None and not args.keys():
+        return url
+    params = [auth.auth()] if auth else []
+    params.extend([k + "=" + urllib.quote(str(v)) for k, v in args.iteritems()])
+    return url + "?" + '&'.join(params)
+
+
+def create_bug(token, product, component, version, title, description,
+               assign_to=None, cc=[], depends=[], blocks=[]):
+    """
+    Create a bugzilla bug.
+    """
+    o = {
+        'product': product,
+        'component': component,
+        'summary': title,
+        'version': version,
+        'description': description,
+        'op_sys': 'All',
+        'platform': 'All',
+        'depends_on': depends,
+        'blocks': blocks,
+        'cc': cc,
+    }
+
+    if assign_to:
+        o['assigned_to'] = assign_to
+        o['status'] = 'ASSIGNED'
+
+    return token.rest_request('POST', 'bug', data=o)
+
+
+def create_attachment(auth, bug, contents,
+                      description="attachment",
+                      filename="attachment", comment="",
+                      reviewers=None, review_flag_id=None,
+                      feedback=None, feedback_flag_id=None):
+    """
+    Post an attachment to a bugzilla bug using BzAPI.
+    """
+    attachment = base64.b64encode(contents)
+
+    o = {
+        'ids': [bug],
+        'data': attachment,
+        'encoding': 'base64',
+        'file_name': filename,
+        'summary': description,
+        'is_patch': True,
+        'content_type': 'text/plain',
+        'flags': [],
+    }
+
+    if reviewers:
+        assert review_flag_id
+        for requestee in reviewers:
+            o['flags'].append({
+                'name': 'review',
+                'requestee': requestee,
+                'status': '?',
+                'type_id': review_flag_id,
+                'new': True,
+            })
+
+    if feedback:
+        assert feedback_flag_id
+        for requestee in feedback:
+            o['flags'].append({
+                'name': 'feedback',
+                'requestee': requestee,
+                'status': '?',
+                'type_id': feedback_flag_id,
+                'new': True,
+            })
+
+    if comment:
+        o['comment'] = comment
+
+    return auth.rest_request('POST', 'bug/%s/attachment' % bug, data=o)
+
+
+def get_attachments(auth, bug):
+    return auth.rest_request('GET', 'bug/%s/attachment' % bug)
+
+
+def obsolete_attachment(auth, attachment):
+    o = {
+        'ids': [attachment['id']],
+        'is_obsolete': True,
+    }
+    return auth.rest_request('PUT', 'bug/attachment/%s' % attachment['id'],
+        data=o)
+
+
+def find_users(auth, search_string):
+    return auth.rest_request('GET', 'user', params={'match': [search_string]})
+
+
+def get_configuration(api_server):
+    url = make_url(api_server, None, 'configuration', {'cached_ok': 1})
+    return urllib2.Request(url, None, JSON_HEADERS)
+
+
+def get_bug(auth, bug, **opts):
+    """
+    Retrieve an existing bug
+    """
+    args = {}
+    if 'include_fields' in opts:
+        args['include_fields'] = ",".join(set(
+            opts['include_fields'] + ['id', 'ref', 'token', 'last_change_time', 'update_token']))
+
+    resp = auth.rest_request('GET', 'bug/%s' % bug, data=args)
+    return resp['bugs'][0]
+
+
+def update_bug(auth, bugid, bugdata):
+    """
+    Update an existing bug. Must pass in an existing bug as a data structure.
+    Mid-air collisions are possible.
+    """
+    return auth.rest_request('PUT', 'bug/%s' % bugid, bugdata)

--- a/bzauth.py
+++ b/bzauth.py
@@ -1,0 +1,242 @@
+# Copyright (C) 2010 Mozilla Foundation
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import os
+import platform
+import time
+import urllib
+import urllib2
+import json
+from mercurial import config, demandimport, util
+from mercurial.i18n import _
+try:
+    import cPickle as pickle
+except:
+    import pickle
+import bz
+
+# requests doesn't like lazy importing
+demandimport.disable()
+import requests
+demandimport.enable()
+
+from mozhg.auth import (
+    getbugzillaauth,
+    win_get_folder_path,
+)
+
+global_cache = None
+
+
+class bzAuth:
+    """
+    A helper class to abstract away authentication details.  There are three
+    allowable types of authentication: apikey, userid/cookie, and
+    username/password.  We encapsulate it here so that functions that
+    interact with bugzilla need only call the 'auth' method on the token
+    to get a correct URL.
+    """
+    typeCookie = 1
+    typeExplicit = 2
+    typeAPIKey = 3
+
+    def __init__(self, url, userid=None, cookie=None, username=None,
+                 password=None, apikey=None):
+        assert (userid and cookie) or (username and password) or apikey
+        assert not ((userid or cookie) and (username or password))
+        if apikey:
+            self._type = self.typeAPIKey
+            self._username = username
+            self._apikey = apikey
+        elif userid:
+            self._type = self.typeCookie
+            self._userid = userid
+            self._cookie = cookie
+            self._username = None
+        else:
+            self._type = self.typeExplicit
+            self._username = username
+            self._password = password
+
+        self._url = url.rstrip('/')
+        self._session = None
+
+    def auth(self):
+        if self._type == self.typeAPIKey:
+            return 'api_key=%s' % self._apikey
+        elif self._type == self.typeCookie:
+            return "userid=%s&cookie=%s" % (self._userid, self._cookie)
+        else:
+            return "username=%s&password=%s" % (urllib.quote(self._username), urllib.quote(self._password))
+
+    def username(self, api_server):
+        # This returns and caches the email-address-like username of the user's ID
+        if self._type == self.typeCookie and self._username is None:
+            resp = self.rest_request('GET', 'user/%s' % self._userid)
+            return resp['users'][0]['name']
+        else:
+            return self._username
+
+    @property
+    def session(self):
+        """Obtain a ``requests.Session`` used for making requests."""
+        if self._session:
+            return self._session
+
+        s = requests.Session()
+        s.headers['User-Agent'] = 'bzexport'
+
+        if self._type == self.typeAPIKey:
+            s.params['api_key'] = self._apikey
+        elif self._type == self.typeCookie:
+            s.cookies['Bugzilla_login'] = self._userid
+            s.cookies['Bugzilla_logincookie'] = self._cookie
+
+            # The REST token is composed of the cookie values. It is arguably
+            # redundant with setting cookies as part of the request. But, error
+            # messages from Bugzilla with cookies defined are slightly better
+            # than errors from invalid tokens, so we set both in hopes it leads
+            # to better error messages.
+            #
+            # It's worth noting that cookies aren't used for auth on GET
+            # requests in the REST API.
+            s.params['token'] = '%s-%s' % (self._userid, self._cookie)
+        else:
+            # Resolve a token.
+            params = {'login': self._username, 'password': self._password}
+            res = s.get('%s/rest/login' % self._url, params=params)
+            j = res.json()
+            if 'token' not in j:
+                raise util.Abort(_('failed to login to Bugzilla'))
+
+            s.params['token'] = j['token']
+
+        s.headers['Content-Type'] = 'application/json'
+        s.headers['Accept'] = 'application/json'
+
+        self._session = s
+        return s
+
+    def rest_request(self, method, path, data=None, **kwargs):
+        """Make a request against the REST API.
+
+        Returns the parsed JSON response as an object or raises if an error
+        occurred.
+        """
+        url = '%s/rest/%s' % (self._url, path.lstrip('/'))
+        if data:
+            data = json.dumps(data)
+
+        res = self.session.request(method, url, data=data, **kwargs)
+
+        j = res.json()
+        if 'error' in j:
+            raise Exception('REST error on %s to %s: %s' % (
+                method, url, j['message']))
+
+        return j
+
+
+def get_global_path(filename):
+    path = None
+    if platform.system() == "Windows":
+        # The Windows user profile directory, eg: C:\Users\username
+        # From http://msdn.microsoft.com/en-us/library/windows/desktop/bb762494%28v=vs.85%29.aspx
+        CSIDL_PROFILE = 40
+        path = win_get_folder_path(CSIDL_PROFILE)
+    else:
+        path = os.path.expanduser("~")
+    if path:
+        path = os.path.join(path, filename)
+    return path
+
+
+def store_global_cache(filename):
+    fp = open(get_global_path(filename), "wb")
+    pickle.dump(global_cache, fp)
+    fp.close()
+
+
+def load_global_cache(ui, api_server, filename):
+    global global_cache
+    if global_cache:
+        return global_cache
+
+    cache_file = get_global_path(filename)
+
+    try:
+        fp = open(cache_file, "rb")
+        global_cache = pickle.load(fp)
+    except IOError, e:
+        global_cache = {api_server: {'real_names': {}}}
+    except Exception, e:
+        raise util.Abort("Error loading user cache: " + str(e))
+
+    return global_cache
+
+
+def store_user_cache(cache, filename):
+    user_cache = get_global_path(filename)
+    fp = open(user_cache, "wb")
+    for section in cache.sections():
+        fp.write("[" + section + "]\n")
+        for (user, name) in cache.items(section):
+            fp.write(user + " = " + name + "\n")
+        fp.write("\n")
+    fp.close()
+
+
+def load_user_cache(ui, api_server, filename):
+    user_cache = get_global_path(filename)
+
+    # Ensure that the cache exists before attempting to use it
+    fp = open(user_cache, "a")
+    fp.close()
+
+    c = config.config()
+    c.read(user_cache)
+    return c
+
+
+def load_configuration(ui, api_server, filename):
+    global_cache = load_global_cache(ui, api_server, filename)
+    cache = {}
+    try:
+        cache = global_cache[api_server]
+    except:
+        global_cache[api_server] = cache
+    now = time.time()
+    if cache.get('configuration', None) and now - cache['configuration_timestamp'] < 24*60*60*7:
+        return cache['configuration']
+
+    ui.write("Refreshing configuration cache for " + api_server + "\n")
+    try:
+        cache['configuration'] = json.load(urllib2.urlopen(bz.get_configuration(api_server), timeout=30))
+    except Exception, e:
+        raise util.Abort("Error loading bugzilla configuration: " + str(e))
+
+    cache['configuration_timestamp'] = now
+    store_global_cache(filename)
+    return cache['configuration']
+
+
+def get_auth(ui, bugzilla, profile):
+    auth = getbugzillaauth(ui, require=True, profile=profile)
+    if auth.apikey:
+        return bzAuth(bugzilla, apikey=auth.apikey, username=auth.username)
+    if auth.userid:
+        return bzAuth(bugzilla, userid=auth.userid, cookie=auth.cookie)
+    return bzAuth(bugzilla, username=auth.username, password=auth.password)

--- a/bzexport.py
+++ b/bzexport.py
@@ -1,0 +1,183 @@
+# Copyright (C) 2010 Mozilla Foundation
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+# Extracted from __init__.py from bzexport.
+
+
+import os
+import platform
+import time
+import urllib
+import urllib2
+import json
+from mercurial import config, demandimport, util
+from mercurial.i18n import _
+try:
+    import cPickle as pickle
+except:
+    import pickle
+import bz
+import bzauth
+
+# requests doesn't like lazy importing
+demandimport.disable()
+import requests
+demandimport.enable()
+
+from auth import (
+    getbugzillaauth,
+    win_get_folder_path,
+)
+
+# For some reason hgexport calls the user cache the INI_CACHE_FILENAME.
+INI_CACHE_FILENAME = ".gitbz.user.cache"
+
+# Returns [ { search_string: original, names: [ str ], real_names: [ str ] } ]
+def find_users(ui, api_server, user_cache_filename, auth, search_strings):
+    c = bzauth.load_user_cache(ui, api_server, user_cache_filename)
+    section = api_server
+
+    search_results = []
+    for search_string in search_strings:
+        name = c.get(section, search_string)
+        if name:
+            search_results.append({"search_string": search_string,
+                                   "names": [name],
+                                   "real_names": ["not_a_real_name"]})
+            continue
+
+        try:
+            try:
+                users = bz.find_users(auth, search_string)
+            except Exception as e:
+                raise util.Abort(e.message)
+            name = None
+            real_names = map(lambda user: "%s <%s>" % (user["real_name"], user["email"])
+                             if user["real_name"] else user["email"], users["users"])
+            names = map(lambda user: user["name"], users["users"])
+            search_results.append({"search_string": search_string,
+                                   "names": names,
+                                   "real_names": real_names})
+            if len(real_names) == 1:
+                c.set(section, search_string, names[0])
+        except Exception, e:
+            search_results.append({"search_string": search_string,
+                                   "error": str(e),
+                                   "real_names": None})
+            raise
+    bzauth.store_user_cache(c, user_cache_filename)
+    return search_results
+
+
+def prompt_manychoice(ui, message, prompts):
+    while True:
+        choice = ui.prompt(message, default='default')
+        if choice == 'default':
+            return 0
+        choice = '&' + choice
+        if choice in prompts:
+            return prompts.index(choice)
+        ui.write("unrecognized response\n")
+
+
+def prompt_menu(ui, name, values,
+                readable_values=None,
+                message='',
+                allow_none=False):
+    if message and not message.endswith('\n'):
+        message += "\n"
+    prompts = []
+    for i in range(0, len(values)):
+        prompts.append("&" + str(i + 1))
+        value = (readable_values or values)[i]
+        message += "  %d. %s\n" % ((i + 1), value.encode('utf-8', 'replace'))
+    if allow_none:
+        prompts.append("&n")
+        message += "  n. None\n\n"
+    prompts.append("&a")
+    message += "  a. Abort\n\n"
+    message += _("Select %s:") % name
+
+    choice = prompt_manychoice(ui, message, prompts)
+
+    if allow_none and choice == len(prompts) - 2:
+        return None
+    if choice == len(prompts) - 1:
+        raise util.Abort("User requested abort while choosing %s" % name)
+    return values[choice]
+
+
+def multi_user_prompt(ui, desc, search_results):
+    return prompt_menu(ui, desc, search_results['names'],
+                       readable_values=search_results['real_names'],
+                       message="Multiple bugzilla users matching \"%s\":\n\n" % search_results["search_string"],
+                       allow_none=True)
+
+# search_strings is a simple list of strings
+def validate_users(ui, api_server, auth, search_strings, multi_callback, multi_desc):
+    search_results = find_users(ui, api_server, INI_CACHE_FILENAME, auth, search_strings)
+    search_failed = False
+    results = {}
+    for search_result in search_results:
+        if search_result["real_names"] is None:
+            ui.write_err("Error: couldn't find user with search string \"%s\": %s\n" %
+                         (search_result["search_string"], search_result["error"]))
+            search_failed = True
+        elif len(search_result["real_names"]) > 10:
+            ui.write_err("Error: too many bugzilla users matching \"%s\":\n\n" % search_result["search_string"])
+            for real_name in search_result["real_names"]:
+                ui.write_err("  %s\n" % real_name.encode('ascii', 'replace'))
+            search_failed = True
+        elif len(search_result["real_names"]) > 1:
+            user = multi_callback(ui, multi_desc, search_result)
+            if user is not None:
+                results[search_result['search_string']] = [user]
+        elif len(search_result["real_names"]) == 1:
+            results[search_result['search_string']] = search_result['names']
+        else:
+            ui.write_err("Couldn't find a bugzilla user matching \"%s\"!\n" % search_result["search_string"])
+            search_failed = True
+    return None if search_failed else results
+
+
+def select_users(valid, keys):
+    if valid is None:
+        return None
+    users = []
+    for key in keys:
+        users.extend(valid[key])
+    return users
+
+
+def flag_type_id(ui, api_server, config_cache_filename, flag_name, product, component):
+    """
+    Look up the numeric type id for the 'review' flag from the given bugzilla server
+    """
+    configuration = bzauth.load_configuration(ui, api_server, config_cache_filename)
+    if not configuration or not configuration["flag_type"]:
+        raise util.Abort(_("Could not find configuration object"))
+
+    # Get the set of flag ids used for this product::component
+    prodflags = configuration['product'][product]['component'][component]['flag_type']
+    flagdefs = configuration['flag_type']
+
+    flag_ids = [id for id in prodflags if flagdefs[str(id)]['name'] == flag_name]
+
+    if len(flag_ids) != 1:
+        raise util.Abort(_("Could not find unique %s flag id") % flag_name)
+
+    return flag_ids[0]

--- a/git-bz
+++ b/git-bz
@@ -62,6 +62,7 @@ default-priority = --
 ################################################################################
 
 import base64
+import bz
 import bzauth
 import getpass
 import mercurial # for mercurial.error.Abort
@@ -74,7 +75,6 @@ from subprocess import Popen, CalledProcessError, PIPE
 import sys
 import tempfile
 import urlparse
-import xmlrpclib
 from xml.etree.cElementTree import ElementTree
 
 
@@ -665,16 +665,23 @@ class BugServer(object):
             print 'Error:', e
             exit(-1)
 
+    def get_product_components(self, product):
+        try:
+            request_string = 'product/{0}?include_fields=components.name'.format(product)
+            product_info = self.auth.rest_request('GET', request_string)['products']
+            assert len(product_info) == 1
+            component_info = product_info[0]['components']
+            component_list = [x['name'] for x in component_info]
+            component_list.sort()
+            return component_list
+        except mercurial.error.Abort, e:
+            print 'Error:', e
+            exit(-1)
+
     def send_request(self, method, url, data=None, headers={}):
         die('unimplemented')
 
     def send_post(self, url, fields, files=None):
-        die('unimplemented')
-
-    def get_xmlrpc_proxy(self):
-        die('unimplemented')
-
-    def product_id(self, product_name):
         die('unimplemented')
 
     def legal_values(self, field):
@@ -1761,19 +1768,10 @@ def do_components(*args):
         if not product:
             die("<product> not specified and no default product is configured" + PRODUCT_COMPONENT_HELP)
 
-    product_id = server.product_id(product)
-    if product_id is None:
-        die("No such product " + product)
+    components = server.get_product_components(product)
+    for c in components:
+        print c
 
-    try:
-        response = server.get_xmlrpc_proxy().Bug.legal_values({'product_id': product_id, 'field': 'component'})
-        components = response['values']
-        for component in components:
-            print component
-    except xmlrpclib.Fault, e:
-        die(e.faultString)
-    except xmlrpclib.ProtocolError, e:
-        die("Unable to retrieve components: %s" % e.errmsg)
 
 ################################################################################
 

--- a/git-bz
+++ b/git-bz
@@ -73,7 +73,6 @@ from subprocess import Popen, CalledProcessError, PIPE
 import sys
 import tempfile
 import time
-import urllib
 import urlparse
 import xmlrpclib
 from xml.etree.cElementTree import ElementTree
@@ -673,45 +672,8 @@ class BugServer(object):
     def get_xmlrpc_proxy(self):
         die('unimplemented')
 
-    def _product_id(self, product_name):
-        # This way works with newer bugzilla; older Bugzilla doesn't support names:
-        try:
-            response = self.get_xmlrpc_proxy().Product.get({ 'names': product_name, 'include_fields': ['id', 'name'] })
-            products = response['products']
-            if len(products) > 0:
-                return products[0]['id']
-        except xmlrpclib.Fault, e:
-            pass
-        except xmlrpclib.ProtocolError, e:
-            pass
-
-        # This should work with any bugzilla that supports xmlrpc, but will be slow
-        print >>sys.stderr, "Searching for product ID ...",
-        try:
-            response = self.get_xmlrpc_proxy().Product.get_accessible_products({})
-            ids = response['ids']
-            response = self.get_xmlrpc_proxy().Product.get_products({ 'ids': ids, 'include_fields': ['id', 'name']})
-            for p in response['products']:
-                if p['name'] == product_name:
-                    print >>sys.stderr, "found it"
-                    return p['id']
-        except xmlrpclib.Fault, e:
-            pass
-        except xmlrpclib.ProtocolError, e:
-            pass
-
-        print >>sys.stderr, "failed"
-        return None
-
     def product_id(self, product_name):
-        key = 'product_id_' + urllib.quote(product_name)
-        try:
-            return cache.get(self.host, key)
-        except IndexError:
-            value = self._product_id(product_name)
-            if value != None:
-                cache.set(self.host, key, value)
-            return value
+        die('unimplemented')
 
     # Query the server for the legal values of the given field; returns an
     # array, or None if the query failed

--- a/git-bz
+++ b/git-bz
@@ -1348,7 +1348,7 @@ class Bug(object):
         print "Bug %d - %s" % (self.id, short_desc)
         print self.get_url()
 
-    def create_patch(self, description, comment, filename, data, obsoletes=[], status='none', review=[], superreview=[], feedback=[], ui_review=[]):
+    def create_patch(self, description, comment, filename, data, obsoletes=[], review=[], superreview=[], feedback=[], ui_review=[]):
         fields = {}
         fields['bugid'] = str(self.id)
         token = self.get_attachment_token()
@@ -1356,7 +1356,6 @@ class Bug(object):
           fields['token'] = token
         fields['action'] = 'insert'
         fields['ispatch'] = '1'
-        fields['attachments.status'] = status
         fields['description'] = description
         if comment:
             fields['comment'] = comment
@@ -1878,7 +1877,7 @@ def edit_attachment_comment(bug, initial_description, initial_body, initial_comm
     return description, comment, commit_message, commit_body, obsoletes, \
            review, superreview, feedback, ui_review
 
-def attach_commits(bug, commits, fill_comment=True, edit=False, status='none'):
+def attach_commits(bug, commits, fill_comment=True, edit=False):
     # We want to attach the patches in chronological order
     commits = list(commits)
     commits.reverse()
@@ -1924,7 +1923,7 @@ def attach_commits(bug, commits, fill_comment=True, edit=False, status='none'):
         hgstring += "# User " + commit_range.author + '\n\n'
         patch = hgstring + patch + '\n'
 
-        bug.create_patch(description, comment, filename, patch, obsoletes=obsoletes, status=status, review=review, superreview=superreview, feedback=feedback, ui_review=ui_review)
+        bug.create_patch(description, comment, filename, patch, obsoletes=obsoletes, review=review, superreview=superreview, feedback=feedback, ui_review=ui_review)
 
 def _get_commits_and_handle(args):
     if len(args) == 1:
@@ -1997,9 +1996,8 @@ def do_attach(*args):
 
     attach_commits(bug, commits, edit=global_options.edit)
 
-def edit_bug(bug, fix_commits=None):
+def edit_bug(bug):
     newly_applied_patches = obsoleted_patches = set()
-    mark_resolved = fix_commits is not None
 
     template = StringIO()
     template.write("# Bug %d - %s - %s" % (bug.id, bug.short_desc, bug.bug_status))
@@ -2009,23 +2007,12 @@ def edit_bug(bug, fix_commits=None):
     template.write("# %s\n" % bug.get_url())
     template.write("# Enter comment on following lines; delete everything to abort\n\n")
 
-    if fix_commits is not None:
-        if len(fix_commits) == 1:
-            template.write("The following fix has been pushed:\n")
-        else:
-            template.write("The following fixes have been pushed:\n")
-        for commit in reversed(fix_commits):
-            template.write(commit.id[0:7] + " " + commit.subject + "\n")
-        template.write("\n")
-
     for patch in bug.patches:
         if patch in newly_applied_patches:
             commit = newly_applied_patches[patch]
             template.write("Attachment %d pushed as %s - %s\n" % (patch.attach_id, commit.id[0:7], commit.subject))
 
-    if mark_resolved:
-        template.write("# Comment to keep bug open\n")
-    elif bug.bug_status == "RESOLVED":
+    if bug.bug_status == "RESOLVED":
         template.write("# Uncommment and edit to change resolution\n")
     else:
         template.write("# Uncomment to resolve bug\n")
@@ -2034,9 +2021,7 @@ def edit_bug(bug, fix_commits=None):
         # Require non-empty resolution. DUPLICATE, MOVED would need special support
         legal_resolutions = [x for x in legal_resolutions if x not in ('', 'DUPLICATE', 'MOVED')]
         template.write("# possible resolutions: %s\n" % abbreviation_help_string(legal_resolutions))
-    if not mark_resolved:
-        template.write("#")
-    template.write("Resolution: FIXED\n")
+    template.write("# Resolution: FIXED\n")
 
     if len(bug.patches) > 0:
         patches_have_status = any((patch.status is not None for patch in bug.patches))
@@ -2090,19 +2075,6 @@ def edit_bug(bug, fix_commits=None):
     if resolution is None and len(changed_attachments) == 0 and comment == "":
         print "No changes, not editing Bug %d - %s" % (bug.id, bug.short_desc)
         return False
-
-    if fix_commits is not None:
-        if global_options.add_url:
-            # We don't want to add the URLs until the user has decided not to
-            # cancel the operation. But the comment that the user edited
-            # included commit IDs. If adding the URL changes the commit IDs
-            # we need to replace them in the comment.
-            old_ids = [(commit, commit.id[0:7]) for commit in fix_commits]
-            add_url(bug, fix_commits)
-            for commit, old_id in old_ids:
-                new_id = commit.id[0:7]
-                if new_id != old_id:
-                    comment = comment.replace(old_id, new_id)
 
     bug_changes = {}
     if resolution is not None:
@@ -2159,9 +2131,6 @@ def edit_bug(bug, fix_commits=None):
             print "Marked attachment as obsolete: %s - %s " % (patch.attach_id, patch.description)
         else:
             print "Changed status of attachment to %s: %s - %s" % (status, patch.attach_id, patch.description)
-
-    if fix_commits is not None:
-        attach_commits(bug, fix_commits, status='committed')
 
     if resolution is not None:
         print "Resolved as %s bug %d - %s" % (resolution, bug.id, bug.short_desc)
@@ -2224,8 +2193,6 @@ def extract_and_collate_bugs(commits):
 def do_edit(bug_reference_or_revision_range):
     try:
         handle = BugHandle.parse(bug_reference_or_revision_range)
-        if global_options.fix is not None:
-            die("--fix requires commits to be specified")
         bug = Bug.load(handle)
         edit_bug(bug)
     except BugParseError, e:
@@ -2234,16 +2201,11 @@ def do_edit(bug_reference_or_revision_range):
         except CalledProcessError:
             die("'%s' isn't a valid bug reference or revision range" % bug_reference_or_revision_range)
 
-        if global_options.fix is not None:
-            handle = BugHandle.parse_or_die(global_options.fix)
+        # Process from oldest to newest
+        commits.reverse()
+        for handle, commits in extract_and_collate_bugs(commits):
             bug = Bug.load(handle)
-            edit_bug(bug, fix_commits=commits)
-        else:
-            # Process from oldest to newest
-            commits.reverse()
-            for handle, commits in extract_and_collate_bugs(commits):
-                bug = Bug.load(handle)
-                edit_bug(bug)
+            edit_bug(bug)
 
 PRODUCT_COMPONENT_HELP = """
 
@@ -2395,10 +2357,6 @@ def add_edit_option():
     parser.add_option("-e", "--edit", action="store_true",
                       help="allow editing the bugzilla comment")
 
-def add_fix_option():
-    parser.add_option("", "--fix", metavar="<bug reference>",
-                      help="attach commits and close bug")
-
 def add_requestee_option():
     parser.add_option("-r", "--requestee", action="store", dest="requestee",
                       help="Only apply commits assigned to this requestee")
@@ -2429,7 +2387,6 @@ elif command == 'components':
 elif command == 'edit':
     parser.set_usage("git bz edit [options] (<bug reference> | <commit> | <revision range>)");
     add_add_url_options()
-    add_fix_option()
     min_args = max_args = 1
 elif command == 'file':
     parser.set_usage("git bz file [options] [[<product>]]/<component>] (<commit> | <revision range>)");

--- a/git-bz
+++ b/git-bz
@@ -2030,11 +2030,12 @@ def edit_bug(bug):
         m = re.match("^\s*(\S+)\s*@\s*(\d+)", line)
         if m:
             status = m.group(1)
-            changed_attachments[int(m.group(2))] = status
-            return False
+            if status == 'obsolete':
+                obsoleted_attachments.append(int(m.group(2)))
+                return False
         return True
 
-    changed_attachments = {}
+    obsoleted_attachments = []
     resolutions = []
 
     lines = filter(filter_line, lines)
@@ -2042,7 +2043,7 @@ def edit_bug(bug):
     comment = "".join(lines).strip()
     resolution = resolutions[0] if len(resolutions) > 0 else None
 
-    if resolution is None and len(changed_attachments) == 0 and comment == "":
+    if resolution is None and len(obsoleted_attachments) == 0 and comment == "":
         print "No changes, not editing Bug %d - %s" % (bug.id, bug.short_desc)
         return False
 
@@ -2057,7 +2058,7 @@ def edit_bug(bug):
         bug_changes['resolution'] = resolution
 
     if comment != "":
-        if len(bug_changes) == 0 and len(changed_attachments) == 1:
+        if len(bug_changes) == 0 and len(obsoleted_attachments) == 1:
             # We can add the comment when we submit the attachment change.
             # Bugzilla will add a helpful notation ad we'll only send out
             # one set of email
@@ -2072,11 +2073,9 @@ def edit_bug(bug):
     if len(bug_changes) > 0:
         bug.update(**bug_changes)
 
-    for (attachment_id, status) in changed_attachments.iteritems():
+    for attachment_id in obsoleted_attachments:
         patch = None
-        if status != "obsolete":
-            die("Can't mark patch as '%s'; only obsolete is supported on %s" % (status,
-                                                                                bug.server.host))
+
         for p in bug.patches:
             if p.attach_id == attachment_id:
                 patch = p
@@ -2091,8 +2090,8 @@ def edit_bug(bug):
 
     if resolution is not None:
         print "Resolved as %s bug %d - %s" % (resolution, bug.id, bug.short_desc)
-    elif len(changed_attachments) > 0:
-        print "Updated bug %d - %s" % (bug.id, bug.short_desc)
+    elif len(obsoleted_attachments) > 0:
+        print "Obsoleted attachments on bug %d - %s" % (bug.id, bug.short_desc)
     else:
         print "Added comment to bug %d - %s" % (bug.id, bug.short_desc)
     print bug.get_url()

--- a/git-bz
+++ b/git-bz
@@ -510,44 +510,6 @@ class BugHandle:
                 (other.host, other.https, other.id))
 
 
-# Based on http://code.activestate.com/recipes/146306/ - Wade Leftwich
-def encode_multipart_formdata(fields, files=None):
-    """
-    fields is a dictionary of { name : value } for regular form fields. if value is a list,
-      one form field is added for each item in the list
-    files is a dictionary of { name : ( filename, content_type, value) } for data to be uploaded as files
-    Return (content_type, body) ready for httplib.HTTPContent instance
-    """
-    BOUNDARY = '----------ThIs_Is_tHe_bouNdaRY_$'
-    CRLF = '\r\n'
-    L = []
-    for key in sorted(fields.keys()):
-        value = fields[key]
-        if isinstance(value, list):
-            for v in value:
-                L.append('--' + BOUNDARY)
-                L.append('Content-Disposition: form-data; name="%s"' % key)
-                L.append('')
-                L.append(v)
-        else:
-            L.append('--' + BOUNDARY)
-            L.append('Content-Disposition: form-data; name="%s"' % key)
-            L.append('')
-            L.append(value)
-    if files:
-        for key in sorted(files.keys()):
-            (filename, content_type, value) = files[key]
-            L.append('--' + BOUNDARY)
-            L.append('Content-Disposition: form-data; name="%s"; filename="%s"' % (key, filename))
-            L.append('Content-Type: %s' % content_type)
-            L.append('')
-            L.append(value)
-    L.append('--' + BOUNDARY + '--')
-    L.append('')
-    body = CRLF.join(L)
-    content_type = 'multipart/form-data; boundary=%s' % BOUNDARY
-    return content_type, body
-
 # Cache of constant-responses per bugzilla server
 # ===============================================
 
@@ -821,8 +783,7 @@ class BugServer(object):
                 return response
 
     def send_post(self, url, fields, files=None):
-        content_type, body = encode_multipart_formdata(fields, files)
-        return self.send_request("POST", url, data=body, headers={ 'Content-Type': content_type })
+        die('unimplemented')
 
     def get_xmlrpc_proxy(self):
         die('unimplemented')

--- a/git-bz
+++ b/git-bz
@@ -956,8 +956,6 @@ class BugServer(object):
 
         self.cookies = get_bugzilla_cookies(host)
 
-        self._xmlrpc_proxy = None
-
     def get_cookie_string(self):
         return ("Bugzilla_login=%s; Bugzilla_logincookie=%s" %
                 (self.cookies['Bugzilla_login'], self.cookies['Bugzilla_logincookie']))
@@ -1059,16 +1057,7 @@ class BugServer(object):
         return self.send_request("POST", url, data=body, headers={ 'Content-Type': content_type })
 
     def get_xmlrpc_proxy(self):
-        if self._xmlrpc_proxy is None:
-            uri = "%s://%s%s/xmlrpc.cgi" % ("https" if self.https else "http",
-                                          self.host, self.path)
-            if self.https:
-                transport = SafeBugTransport(self)
-            else:
-                transport = BugTransport(self)
-            self._xmlrpc_proxy = xmlrpclib.ServerProxy(uri, transport)
-
-        return self._xmlrpc_proxy
+        die('unimplemented')
 
     def _product_id(self, product_name):
         # This way works with newer bugzilla; older Bugzilla doesn't support names:
@@ -1136,25 +1125,6 @@ class BugServer(object):
             cache.set(self.host, 'legal_' + field, values)
             return values
 
-# mixin for xmlrpclib.Transport classes to add cookies
-class CookieTransportMixin(object):
-    def send_request(self, connection, *args):
-        xmlrpclib.Transport.send_request(self, connection, *args)
-        cookie = self.server.get_cookie_string()
-        if isinstance(cookie, unicode):
-            cookie = cookie.encode('UTF-8')
-        connection.putheader("Cookie", cookie)
-        connection.putheader("Authorization", http_auth_header(self.server.auth_user, self.server.auth_password))
-
-class BugTransport(CookieTransportMixin, xmlrpclib.Transport):
-    def __init__(self, server):
-        xmlrpclib.Transport.__init__(self)
-        self.server = server
-
-class SafeBugTransport(CookieTransportMixin, xmlrpclib.SafeTransport):
-    def __init__(self, server):
-        xmlrpclib.SafeTransport.__init__(self)
-        self.server = server
 
 servers = {}
 

--- a/git-bz
+++ b/git-bz
@@ -62,6 +62,7 @@ default-priority = --
 ################################################################################
 
 import base64
+import getpass
 from optparse import OptionParser
 import os
 import re
@@ -611,8 +612,55 @@ class BugPatch(object):
     def __init__(self, attach_id):
         self.attach_id = attach_id
 
+
 class NoXmlRpcError(Exception):
     pass
+
+
+class ShimMercurialUI:
+    def config(self, key1, key2, default=None):
+        if key1 != 'bugzilla':
+            print 'Expected bugzilla for first argument to config.'
+            exit(-1)
+        try:
+            return git.config('bz.' + key2, get=True)
+        except CalledProcessError:
+            return default
+
+    def configlist(self, key1, key2, arg3):
+        if key1 != 'bugzilla':
+            print 'Expected bugzilla for first argument to configlist.'
+            exit(-1)
+        if key2 != 'firefoxprofile':
+            print 'Expected firefoxprofile for second argument to configlist.'
+            exit(-1)
+        if len(arg3) != 0:
+            print 'Expected [] for third argument to configlist.'
+        # Don't try to support this.
+        return None
+
+    def debug(self, msg):
+        print 'Debug:', msg
+
+    def getpass(self, message, default=None):
+        return getpass.getpass(message)
+
+    def prompt(self, message, default=None):
+        sys.stdout.write(message + ' ')
+        line = sys.stdin.readline().strip()
+        if line == '':
+            return default
+        return line
+
+    def warn(self, msg):
+        print 'Warn:', msg
+
+    def write(self, msg):
+        print msg
+
+    def write_err(self, msg):
+        print 'Error:', msg
+
 
 class BugServer(object):
     def __init__(self, host, path, https, auth_user=None, auth_password=None):

--- a/git-bz
+++ b/git-bz
@@ -694,10 +694,34 @@ class BugServer(object):
             print 'Error:', e
             exit(-1)
 
-    def send_post(self, url, fields, files=None):
-        die('unimplemented')
+    def legal_field_values(self, field_name):
+        # XXX Should cache this.
+        vals = self.auth.rest_request('GET', 'field/bug/' + field_name + '?include_fields=values')
+        vals = vals['fields'][0]['values']
+        return [x['name'] for x in vals]
 
-    def legal_values(self, field):
+    # Note that if a comment is given when obsoleting multiple attachments,
+    # the comment will be posted repeatedly. See bug 1206797.
+    def obsolete_attachments_by_id(self, attachment_ids, comment=''):
+        if not attachment_ids:
+            return
+        try:
+            o = {
+                'ids': attachment_ids,
+                'is_obsolete': True,
+            }
+            if comment:
+                o['comment'] = comment
+
+            return self.auth.rest_request('PUT', 'bug/attachment/%s' % attachment_ids[0], data=o)
+        except mercurial.error.Abort, e:
+            print 'Error:', e
+            exit(-1)
+
+    def update_bug(self, bug_id, changes):
+        bz.update_bug(self.auth, bug_id, changes)
+
+    def send_post(self, url, fields, files=None):
         die('unimplemented')
 
 
@@ -907,60 +931,11 @@ class Bug(object):
 
         print "Attached %s" % filename
 
-    # Update specified fields of a bug; keyword arguments are interpreted
-    # as field_name=value
-    def update(self, **changes):
-        changes['id'] = str(self.id)
-        if self.token:
-            changes['token'] = self.token
-        # Since we don't send delta_ts we'll never get a mid-air collision
-        # This is probably a good thing
-
-        response = self.server.send_post("/process_bug.cgi", changes)
-        response_data = response.read()
-        if not check_for_success(response, response_data,
-                                 r"<title>\s*Bug[\S\s]*processed\s*</title>"):
-
-            # Mid-air collisions would be indicated by
-            # "<title>Mid-air collision!</title>"
-
-            print response_data
-            die ("Failed to update bug %d, status=%d" % (self.id, response.status))
-
-    # Update specified fields of an attachment; keyword arguments are
-    # interpreted as field_name=value
-    def update_patch(self, patch, **changes):
-        # Unlike /process_bug.cgi, the attachment editing interface doesn't
-        # support defaulting missing fields to their existing values, so we
-        # have to pass everything back.
-        fields = {
-            'action': 'update',
-            'id': str(patch.attach_id),
-            'description': patch.description,
-            'filename': patch.filename,
-            'ispatch': "1",
-            'isobsolete': "0",
-            'isprivate': "1" if patch.isprivate else "0",
-        };
-
-        if patch.token:
-            fields['token'] = patch.token
-
-        for (field, value) in changes.iteritems():
-            fields[field] = value
-
-        response = self.server.send_post("/attachment.cgi", fields)
-        response_data = response.read()
-        if not check_for_success(response, response_data,
-                                 r"<title>\s*Changes\s+Submitted"):
-            print response_data
-            die ("Failed to update attachment %d to bug %d, status=%d" % (patch.attach_id,
-                                                                          self.id,
-                                                                          response.status))
-
     def get_url(self):
         return "%sshow_bug.cgi?id=%d" % (self.server.bugzilla, self.id)
 
+    def update(self, changes):
+        self.server.update_bug(self.id, changes)
 
     @staticmethod
     def load(bug_reference, attachment_data=False):
@@ -1492,7 +1467,7 @@ def edit_bug(bug):
         template.write("# Uncommment and edit to change resolution\n")
     else:
         template.write("# Uncomment to resolve bug\n")
-    legal_resolutions = bug.server.legal_values('resolution')
+    legal_resolutions = bug.server.legal_field_values('resolution')
     if legal_resolutions:
         # Require non-empty resolution. DUPLICATE, MOVED would need special support
         legal_resolutions = [x for x in legal_resolutions if x not in ('', 'DUPLICATE', 'MOVED')]
@@ -1540,39 +1515,24 @@ def edit_bug(bug):
                 resolution = expand_abbreviation(resolution, legal_resolutions)
             except ValueError:
                 die("Bad resolution: %s" % resolution)
-        bug_changes['bug_status'] = 'RESOLVED'
         bug_changes['resolution'] = resolution
 
-    if comment != "":
-        if len(bug_changes) == 0 and len(obsoleted_attachments) == 1:
-            # We can add the comment when we submit the attachment change.
-            # Bugzilla will add a helpful notation ad we'll only send out
-            # one set of email
-            pass # We'll put the comment with the attachment
-        else:
-            bug_changes['comment'] = comment
+    if comment:
+        # If we're updating the bug anyways, add the comment at the
+        # same time. If we're obsoleting multiple attachments at once,
+        # add the comment separately so that it isn't added once per
+        # attachment. See bug 1206797. Finally, if we are only adding
+        # a comment, make sure we update the bug.
+        if bug_changes or len(obsoleted_attachments) != 1:
+            bug_changes['comment'] = { 'body': comment }
+            comment = ''
 
-    # If we did the attachment updates first, we'd have to fetch a new
-    # token hash for the bug, since they'll change it. But each attachment
-    # has an individual token hash for just that attachment, so we can
-    # do the attachment updates afterwards.
-    if len(bug_changes) > 0:
-        bug.update(**bug_changes)
+    if bug_changes:
+        bug.update(bug_changes)
 
-    for attachment_id in obsoleted_attachments:
-        patch = None
-
-        for p in bug.patches:
-            if p.attach_id == attachment_id:
-                patch = p
-        if not patch:
-            die("%d is not a valid attachment ID for Bug %d" % (attachment_id, bug.id))
-        attachment_changes = {}
-        if comment != "" and not 'comment' in bug_changes: # See above
-            attachment_changes['comment'] = comment
-        attachment_changes['isobsolete'] = "1"
-        bug.update_patch(patch, **attachment_changes)
-        print "Marked attachment as obsolete: %s - %s " % (patch.attach_id, patch.description)
+    if obsoleted_attachments:
+        assert len(obsoleted_attachments) == 1 or not comment
+        bug.server.obsolete_attachments_by_id(obsoleted_attachments, comment)
 
     if resolution is not None:
         print "Resolved as %s bug %d - %s" % (resolution, bug.id, bug.short_desc)

--- a/git-bz
+++ b/git-bz
@@ -75,7 +75,6 @@ from subprocess import Popen, CalledProcessError, PIPE
 import sys
 import tempfile
 import urlparse
-from xml.etree.cElementTree import ElementTree
 
 
 # Globals
@@ -665,6 +664,23 @@ class BugServer(object):
             print 'Error:', e
             exit(-1)
 
+    def get_attachments(self, bugid, attachment_data=False):
+        try:
+            request = 'bug/%s/attachment' % bugid
+            if not attachment_data:
+                request = request + '?exclude_fields=data'
+            return self.auth.rest_request('GET', request)['bugs'][bugid]
+        except mercurial.error.Abort, e:
+            print 'Error:', e
+            exit(-1)
+
+    def get_bug(self, bugid):
+        try:
+            return bz.get_bug(self.auth, bugid)
+        except mercurial.error.Abort, e:
+            print 'Error:', e
+            exit(-1)
+
     def get_product_components(self, product):
         try:
             request_string = 'product/{0}?include_fields=components.name'.format(product)
@@ -677,9 +693,6 @@ class BugServer(object):
         except mercurial.error.Abort, e:
             print 'Error:', e
             exit(-1)
-
-    def send_request(self, method, url, data=None, headers={}):
-        die('unimplemented')
 
     def send_post(self, url, fields, files=None):
         die('unimplemented')
@@ -707,6 +720,17 @@ def check_for_success(response, response_data, *args):
     die('unimplemented')
 
 
+class BugAttachment:
+    def __init__(self, raw_attachment):
+        self.attach_id = raw_attachment['id']
+        self.description = raw_attachment['summary']
+        self.flag_requestees = set(flag.get('requestee') for flag in raw_attachment['flags'])
+        if 'data' in raw_attachment:
+            self.data = base64.b64decode(raw_attachment['data'])
+        else:
+            self.data = None
+
+
 class Bug(object):
     def __init__(self, server):
         self.server = server
@@ -716,53 +740,23 @@ class Bug(object):
         self.short_desc = None
         self.patches = []
 
-    def _load(self, id, attachment_data=False):
-        url = "/show_bug.cgi?id=" + id + "&ctype=xml&format=default"
-        if not attachment_data:
-            url += "&excludefield=attachment_data"
-
-        response = self.server.send_request("GET", url)
-        if response.status != 200:
-            die ("Failed to retrieve bug information: %d" % response.status)
-
-        etree = ElementTree()
-        etree.parse(response)
-
-        bug = etree.find("bug")
-        error = bug.get("error")
-        if error != None:
-            die ("Failed to retrieve bug information: %s" % error)
-
-        self.id = int(bug.find("bug_id").text)
-        self.short_desc = bug.find("short_desc").text
-        self.bug_status = bug.find("bug_status").text
+    def _load(self, bugid, attachment_data=False):
+        buginfo = self.server.get_bug(bugid)
+        self.id = buginfo['id']
+        self.product = buginfo['product']
+        self.component = buginfo['component']
+        self.short_desc = buginfo['summary']
+        self.bug_status = buginfo['status']
         if self.bug_status == "RESOLVED":
-            self.resolution = bug.find("resolution").text
-        token = bug.find("token")
-        self.token = None if token is None else token.text
+            self.resolution = buginfo['resolution']
 
-        for attachment in bug.findall("attachment"):
-            if attachment.get("ispatch") == "1" and not attachment.get("isobsolete") == "1" :
-                attach_id = int(attachment.find("attachid").text)
-                patch = BugPatch(attach_id)
-                # We have to save fields we might not otherwise care about
-                # (like isprivate) so that we can pass them back when updating
-                # the attachment
-                patch.description = attachment.find("desc").text
-                patch.date = attachment.find("date").text
-                patch.filename = attachment.find("filename").text
-                patch.isprivate = attachment.get("isprivate") == "1"
-                token = attachment.find("token")
-                patch.token = None if token is None else token.text
-                patch.flag_requestees = set(flag.get("requestee") for flag in attachment.findall("flag"))
-
-                if attachment_data:
-                    data = attachment.find("data").text
-                    patch.data = base64.b64decode(data)
-                else:
-                    patch.data = None
-
-                self.patches.append(patch)
+        attachments = self.server.get_attachments(bugid, attachment_data=attachment_data)
+        for a in attachments:
+            if not a["is_patch"]:
+                continue
+            if a["is_obsolete"]:
+                continue
+            self.patches.append(BugAttachment(a))
 
     def get_attachment_token(self):
         die('unimplemented')

--- a/git-bz
+++ b/git-bz
@@ -2348,71 +2348,6 @@ def do_file(*args):
     attach_commits(bug, commits, fill_comment=fill_comment,
                    edit=global_options.edit)
 
-def run_push(*args, **kwargs):
-    # Predicting what 'git pushes' pushes based on the command line
-    # would be extraordinarily complex, but the interactive output goes
-    # to stderr and is somewhat ambiguous. We do the best we can parsing
-    # it. git 1.6.4 adds --porcelain to push, so we can use that eventually.
-    dry = kwargs['dry'] if 'dry' in kwargs else False
-    options = dict()
-    if dry:
-        options['dry'] = True
-    if global_options.force:
-        options['force'] = True
-    try:
-        options['_return_stderr']=True
-        out, err = git.push(*args, **options)
-    except CalledProcessError:
-        return
-    if not dry:
-        # Echo the output so the user gets feedback about what happened
-        print >>sys.stderr, err
-
-    commits = []
-    for line in err.strip().split("\n"):
-        #
-        # We only look for updates of existing branches; a much more complex
-        # handling would be look for all commits that weren't pushed to a
-        # remote branch. Hopefully the typical use of 'git bz push' is pushing
-        # a single commit to master.
-        #
-        #                 e5ad33e..febe0d4             master  ->   master
-        m = re.match(r"^\s*([a-f0-9]{6,}..[a-f0-9]{6,})\s+\S+\s*->\s*\S+\s*$", line)
-        if m:
-            branch_commits = get_commits(m.group(1))
-            # Process from oldest to newest
-            branch_commits.reverse()
-            commits += branch_commits
-
-    # Remove duplicate commits
-    seen_commit_ids = set()
-    unique_commits = []
-    for commit in commits:
-        if not commit.id in seen_commit_ids:
-            seen_commit_ids.add(commit.id)
-            unique_commits.append(commit)
-
-    return unique_commits
-
-def do_push(*args):
-    if global_options.fix:
-        handle = BugHandle.parse_or_die(global_options.fix)
-        bug = Bug.load(handle)
-
-        # We need the user to confirm before we add the URLs to the commits
-        # We need to add the URLs to the commits before we push
-        # We need to push in order to find out what commits we are pushing
-        # So, we push --dry first
-        options = { 'dry' : True }
-        commits = run_push(*args, **options)
-        if edit_bug(bug, fix_commits=commits):
-            run_push(*args)
-    else:
-        unique_commits = run_push(*args)
-        for handle, commits in extract_and_collate_bugs(unique_commits):
-            bug = Bug.load(handle)
-            edit_bug(bug, commits)
-
 def do_components(*args):
     server = tracker_get_bug_server(get_tracker())
 
@@ -2503,16 +2438,8 @@ elif command == 'file':
     add_whitespace_option()
     min_args = 1
     max_args = 2
-elif command == 'push':
-    parser.set_usage("git bz push [options] [<repository> <refspec>...]");
-    add_add_url_options()
-    add_fix_option()
-    parser.add_option("-f", "--force", action="store_true",
-                      help="allow non-fast-forward commits")
-    min_args = 0
-    max_args = 1000 # no max
 else:
-    print >>sys.stderr, "Usage: git bz [add-url|apply|attach|components|edit|file|push] [options]"
+    print >>sys.stderr, "Usage: git bz [add-url|apply|attach|components|edit|file] [options]"
     sys.exit(1)
 
 global_options, args = parser.parse_args()
@@ -2536,7 +2463,5 @@ elif command == 'edit':
     do_edit(*args)
 elif command == 'file':
     do_file(*args)
-elif command == 'push':
-    do_push(*args)
 
 sys.exit(0)

--- a/git-bz
+++ b/git-bz
@@ -1244,8 +1244,6 @@ class Bug(object):
                 # the attachment
                 patch.description = attachment.find("desc").text
                 patch.date = attachment.find("date").text
-                status = attachment.find("status")
-                patch.status = None if status is None else status.text
                 patch.filename = attachment.find("filename").text
                 patch.isprivate = attachment.get("isprivate") == "1"
                 token = attachment.find("token")
@@ -1460,12 +1458,8 @@ class Bug(object):
 
         if patch.token:
             fields['token'] = patch.token
-        if patch.status is not None:
-            fields['attachments.status'] = patch.status
 
         for (field, value) in changes.iteritems():
-            if field == 'status': # encapsulate oddball form field name
-                field = 'attachments.status'
             fields[field] = value
 
         response = self.server.send_post("/attachment.cgi", fields)
@@ -1714,10 +1708,6 @@ def do_apply(bug_reference):
     print
 
     for patch in bug.patches:
-        if patch.status == 'committed' or patch.status == 'rejected':
-            print "Skipping, %s: %s" % (patch.status, patch.description)
-            continue
-
         if not requestee_match(patch.flag_requestees):
             print "Skipping patch for %s: %s" % (patch.flag_requestees,
                                                  patch.description)
@@ -2024,29 +2014,9 @@ def edit_bug(bug):
     template.write("# Resolution: FIXED\n")
 
     if len(bug.patches) > 0:
-        patches_have_status = any((patch.status is not None for patch in bug.patches))
-        if patches_have_status:
-            if len(newly_applied_patches) > 0 or len(obsoleted_patches) > 0:
-                template.write("\n# Lines below change patch status, unless commented out\n")
-            else:
-                template.write("\n# To change patch status, uncomment below, edit 'committed' as appropriate.\n")
-            legal_statuses = bug.server.legal_values('attachments.status')
-            if legal_statuses:
-                legal_statuses.append('obsolete')
-                template.write("# possible statuses: %s\n" % abbreviation_help_string(legal_statuses))
-
-            for patch in bug.patches:
-                if patch in newly_applied_patches:
-                    new_status = "committed"
-                elif patch in obsoleted_patches:
-                    new_status = "obsolete"
-                else:
-                    new_status = "#committed"
-                template.write("%s @%d - %s - %s\n" % (new_status, patch.attach_id, patch.description, patch.status))
-        else:
-            template.write("\n# To mark patches obsolete, uncomment below\n")
-            for patch in bug.patches:
-                template.write("#obsolete @%d - %s\n" % (patch.attach_id, patch.description))
+        template.write("\n# To mark patches obsolete, uncomment below\n")
+        for patch in bug.patches:
+            template.write("#obsolete @%d - %s\n" % (patch.attach_id, patch.description))
 
         template.write("\n")
 
@@ -2104,16 +2074,9 @@ def edit_bug(bug):
 
     for (attachment_id, status) in changed_attachments.iteritems():
         patch = None
-        if patches_have_status:
-            if legal_statuses:
-                try:
-                    status = expand_abbreviation(status, legal_statuses)
-                except ValueError:
-                    die("Bad patch status: %s" % status)
-        else:
-            if status != "obsolete":
-                die("Can't mark patch as '%s'; only obsolete is supported on %s" % (status,
-                                                                                    bug.server.host))
+        if status != "obsolete":
+            die("Can't mark patch as '%s'; only obsolete is supported on %s" % (status,
+                                                                                bug.server.host))
         for p in bug.patches:
             if p.attach_id == attachment_id:
                 patch = p
@@ -2122,15 +2085,9 @@ def edit_bug(bug):
         attachment_changes = {}
         if comment != "" and not 'comment' in bug_changes: # See above
             attachment_changes['comment'] = comment
-        if status == 'obsolete':
-            attachment_changes['isobsolete'] = "1"
-        else:
-            attachment_changes['status'] = status
+        attachment_changes['isobsolete'] = "1"
         bug.update_patch(patch, **attachment_changes)
-        if status == 'obsolete':
-            print "Marked attachment as obsolete: %s - %s " % (patch.attach_id, patch.description)
-        else:
-            print "Changed status of attachment to %s: %s - %s" % (status, patch.attach_id, patch.description)
+        print "Marked attachment as obsolete: %s - %s " % (patch.attach_id, patch.description)
 
     if resolution is not None:
         print "Resolved as %s bug %d - %s" % (resolution, bug.id, bug.short_desc)

--- a/git-bz
+++ b/git-bz
@@ -1281,19 +1281,18 @@ def edit_attachment_comment(bug, initial_description, initial_body, initial_comm
     for line in lines:
         # Capture a |Metadata:| formatted line and stuff it into the relevant
         # list
-        def append_matching_group(key, list, line, content_regexp='.+'):
+        def append_matching_group(key, retfn, line, content_regexp='.+'):
             match = re.match("^\s*%s\s*:\s*(%s)" % (key, content_regexp), line)
             if match:
-                list.append(match.group(1).strip())
+                retfn(match.group(1).strip())
                 return True
             return False
-
-        if append_matching_group("Obsoletes", obsoletes, line, content_regexp="[\d]+") or \
-           append_matching_group("Review", review, line) or \
-           append_matching_group("Super-Review", superreview, line) or \
-           append_matching_group("Feedback", feedback, line) or \
-           append_matching_group("ui-review", ui_review, line) or \
-           append_matching_group("Commit-Message", commit_message, line):
+        if append_matching_group("Obsoletes", obsoletes.append, line, content_regexp="[\d]+") or \
+           append_matching_group("Review", review.append, line) or \
+           append_matching_group("Super-Review", superreview.append, line) or \
+           append_matching_group("Feedback", feedback.append, line) or \
+           append_matching_group("ui-review", ui_review.append, line) or \
+           append_matching_group("Commit-Message", commit_message.append, line):
             continue
 
         # The Commit-Message: line delineates the break between the attachment

--- a/git-bz
+++ b/git-bz
@@ -755,6 +755,12 @@ class BugAttachment:
             self.data = None
 
 
+class AttachmentFlagValues:
+    def __init__(self):
+        self.status = None
+        self.requestees = []
+
+
 class Bug(object):
     def __init__(self, server):
         self.server = server
@@ -857,7 +863,7 @@ class Bug(object):
         print "Bug %d - %s" % (self.id, short_desc)
         print self.get_url()
 
-    def create_patch(self, description, comment, filename, data, obsoletes=[], review=[], superreview=[], feedback=[], ui_review=[]):
+    def create_patch(self, description, comment, filename, data, obsoletes=[], patch_flags={}):
         fields = {}
         fields['bugid'] = str(self.id)
         token = self.get_attachment_token()
@@ -885,6 +891,7 @@ class Bug(object):
         superreview_flag = 5
         feedback_flag = 607
         ui_review_flag = 203
+        die('flag code not updated for the new combined format')
         if review:
             if review[0] == ':me+':
                 fields['flag_type-%d' % review_flag] = '+'
@@ -1270,10 +1277,17 @@ def edit_attachment_comment(bug, initial_description, initial_body, initial_comm
     lines = edit_template(template.getvalue())
 
     obsoletes = []
-    review = []
-    superreview = []
-    feedback = []
-    ui_review = []
+    patch_flags = {}
+
+    def add_patch_flag(flag_name):
+        def set_for_flag(requestee):
+            fv = patch_flags.setdefault(flag_name, AttachmentFlagValues())
+            if requestee == ':me+':
+                assert fv.status is None or fv.status == '+'
+                fv.status = '+'
+            else:
+                fv.requestees.append(requestee)
+        return set_for_flag
 
     commit_message = []
     comment_lines = []
@@ -1288,10 +1302,10 @@ def edit_attachment_comment(bug, initial_description, initial_body, initial_comm
                 return True
             return False
         if append_matching_group("Obsoletes", obsoletes.append, line, content_regexp="[\d]+") or \
-           append_matching_group("Review", review.append, line) or \
-           append_matching_group("Super-Review", superreview.append, line) or \
-           append_matching_group("Feedback", feedback.append, line) or \
-           append_matching_group("ui-review", ui_review.append, line) or \
+           append_matching_group("Review", add_patch_flag("review"), line) or \
+           append_matching_group("Super-Review", add_patch_flag("superreview"), line) or \
+           append_matching_group("Feedback", add_patch_flag("feedback"), line) or \
+           append_matching_group("ui-review", add_patch_flag("ui-review"), line) or \
            append_matching_group("Commit-Message", commit_message.append, line):
             continue
 
@@ -1324,8 +1338,7 @@ def edit_attachment_comment(bug, initial_description, initial_body, initial_comm
         commit_message = description
         commit_body = comment
 
-    return description, comment, commit_message, commit_body, obsoletes, \
-           review, superreview, feedback, ui_review
+    return description, comment, commit_message, commit_body, obsoletes, patch_flags
 
 def attach_commits(bug, commits, fill_comment=True, edit=False):
     # We want to attach the patches in chronological order
@@ -1351,17 +1364,13 @@ def attach_commits(bug, commits, fill_comment=True, edit=False):
         else:
             comment = None
         if edit:
-            description, comment, commit_message, commit_body, obsoletes, \
-                review, superreview, feedback, ui_review = \
-                    edit_attachment_comment(bug, commit_range.subject, commit_body, comment)
+            description, comment, commit_message, commit_body, obsoletes, patch_flags = \
+                edit_attachment_comment(bug, commit_range.subject, commit_body, comment)
         else:
             description = strip_bug_prefix(bug, commit_range.subject)
             commit_message = commit_range.subject
             obsoletes = []
-            review = []
-            superreview = []
-            feedback = []
-            ui_review = []
+            patch_flags = {}
         # Prepend the body
         if commit_body:
             patch = commit_body + "\n\n" + patch
@@ -1373,7 +1382,7 @@ def attach_commits(bug, commits, fill_comment=True, edit=False):
         hgstring += "# User " + commit_range.author + '\n\n'
         patch = hgstring + patch + '\n'
 
-        bug.create_patch(description, comment, filename, patch, obsoletes=obsoletes, review=review, superreview=superreview, feedback=feedback, ui_review=ui_review)
+        bug.create_patch(description, comment, filename, patch, obsoletes=obsoletes, patch_flags=patch_flags)
 
 def _get_commits_and_handle(args):
     if len(args) == 1:

--- a/git-bz
+++ b/git-bz
@@ -67,13 +67,7 @@ from ConfigParser import RawConfigParser, NoOptionError
 import httplib
 from optparse import OptionParser
 import os
-import platform
 import re
-import shutil
-try:
-    from sqlite3 import dbapi2 as sqlite
-except ImportError:
-    from pysqlite2 import dbapi2 as sqlite
 from splitreviewer import split_reviewer
 from StringIO import StringIO
 from subprocess import Popen, CalledProcessError, PIPE
@@ -261,12 +255,6 @@ def commit_is_merge(commit):
 # Global configuration variables
 # ==============================
 
-def get_browser():
-    try:
-        return git.config('bz.browser', get=True)
-    except CalledProcessError:
-        return 'firefox3'
-
 def get_tracker():
     if global_options.bugzilla != None:
         return global_options.bugzilla
@@ -306,11 +294,6 @@ def get_add_url_ignore_remote_commits():
     except CalledProcessError:
         return False
 
-def get_firefox_profile_pref():
-    try:
-        return git.config('bz.firefox-profile', get=True)
-    except CalledProcessError:
-        return ""
 
 # Per-tracker configuration variables
 # ===================================
@@ -526,218 +509,6 @@ class BugHandle:
         return ((self.host, self.https, self.id) ==
                 (other.host, other.https, other.id))
 
-class CookieError(Exception):
-    pass
-
-def do_get_cookies_from_sqlite(host, cookies_sqlite, browser, query, chromium_time):
-    result = {}
-    # We use a timeout of 0 since we expect to hit the browser holding
-    # the lock often and we need to fall back to making a copy without a delay
-    connection = sqlite.connect(cookies_sqlite, timeout=0)
-
-    try:
-        cursor = connection.cursor()
-        cursor.execute(query, { 'host': host })
-
-        now = time.time()
-        for name,value,path,expiry in cursor.fetchall():
-            # Excessive caution: toss out values that need to be quoted in a cookie header
-            expiry = float(expiry)
-            if chromium_time:
-                # Time stored in microseconds since epoch
-                expiry /= 1000000.
-                # Old chromium versions used to use the Unix epoch, but newer versions
-                # use the Windows epoch of January 1, 1601. Convert the latter to Unix epoch
-                if expiry > 11644473600:
-                    expiry -= 11644473600
-            if float(expiry) > now and not re.search(r'[()<>@,;:\\"/\[\]?={} \t]', value):
-                result[name] = value
-
-        return result
-    # Let the user know what might be going wrong in the case of a cryptic database error.
-    except sqlite.DatabaseError, e:
-        if "file is encrypted or is not a database" in str(e) and get_sqlite3():
-            # Try using the sqlite3 command line tool on OS X (since the MacPorts pysqlite is too old)
-            return get_cookies_from_sqlite_with_sqlite3(host, cookies_sqlite, browser, query,
-                                                        chromium_time=chromium_time)
-        else:
-            print ("Python threw a database error. A likely cause is that your version of python "
-                   "doesn't have a recent enough sqlite module to support this cookie database. "
-                   "Try upgrading your python sqlite module.")
-            raise
-    finally:
-        connection.close()
-
-# Firefox 3.5 keeps the cookies database permamently locked; as a workaround
-# hack, we make a copy, read from that, then delete the copy. Of course,
-# we may hit an inconsistent state of the database
-def get_cookies_from_sqlite_with_copy(host, cookies_sqlite, browser, *args, **kwargs):
-    db_copy = cookies_sqlite + ".git-bz-temp"
-    shutil.copyfile(cookies_sqlite, db_copy)
-    try:
-        return do_get_cookies_from_sqlite(host, db_copy, browser, *args, **kwargs)
-    except sqlite.OperationalError, e:
-        raise CookieError("Cookie database was locked; temporary copy didn't work")
-    finally:
-        os.remove(db_copy)
-
-def get_sqlite3():
-    for dirname in os.environ['PATH'].split(":"):
-        path = os.path.join(dirname, 'sqlite3')
-        if os.path.isfile(path) and os.access(path, os.X_OK):
-          return path
-    return False
-
-def get_cookies_from_sqlite_with_sqlite3(host, cookies_sqlite, browser, query, chromium_time):
-    sqlite3 = get_sqlite3()
-    query = query.replace(':host', '"' + host + '"') + ';'
-    process = Popen([sqlite3, cookies_sqlite], stdout=PIPE, stderr=PIPE, stdin=PIPE)
-    output, error = process.communicate(query)
-    if process.returncode != 0:
-        raise CalledProcessError(process.returncode, sqlite3)
-    cookies = {}
-    for line in output.split("\n"):
-        fields = line.split("|")
-        if (fields[0] == 'Bugzilla_login'):
-            cookies['Bugzilla_login'] = fields[1]
-        elif (fields[0] == 'Bugzilla_logincookie'):
-            cookies['Bugzilla_logincookie'] = fields[1]
-    return cookies
-
-def get_cookies_from_sqlite(host, cookies_sqlite, browser, query, chromium_time=False):
-    try:
-        result = do_get_cookies_from_sqlite(host, cookies_sqlite, browser, query,
-                                            chromium_time=chromium_time)
-    except sqlite.OperationalError, e:
-        if "database is locked" in str(e):
-            # Try making a temporary copy
-            result = get_cookies_from_sqlite_with_copy(host, cookies_sqlite, browser, query,
-                                                       chromium_time=chromium_time)
-        else:
-            raise
-
-    if not ('Bugzilla_login' in result and 'Bugzilla_logincookie' in result):
-        raise CookieError("You don't appear to be signed into %s; please log in with %s" % (host,
-                                                                                            browser))
-
-    return result
-
-def get_cookies_from_sqlite_xulrunner(host, cookies_sqlite, name):
-    return get_cookies_from_sqlite(host, cookies_sqlite, name,
-                                   "select name,value,path,expiry from moz_cookies where host = :host")
-
-def get_bugzilla_cookies_ff3(host):
-    if (platform.system() == "Darwin"):
-        profiles_dir = os.path.expanduser('~/Library/Application Support/Firefox')
-    else:
-        profiles_dir = os.path.expanduser('~/.mozilla/firefox')
-
-    profile_path = None
-    specific_profile = get_firefox_profile_pref()
-
-    cp = RawConfigParser()
-    cp.read(os.path.join(profiles_dir, "profiles.ini"))
-    for section in cp.sections():
-        if not cp.has_option(section, "Path"):
-            continue
-
-        # If we're looking for a specific profile, just check for that
-        if specific_profile != "":
-            if cp.has_option(section, "Name") and cp.get(section, "Name").strip() == specific_profile:
-                profile_path = os.path.join(profiles_dir, cp.get(section, "Path").strip())
-
-        # Otherwise use the profile tagged as default
-        elif (not profile_path or
-            (cp.has_option(section, "Default") and cp.get(section, "Default").strip() == "1")):
-            profile_path = os.path.join(profiles_dir, cp.get(section, "Path").strip())
-
-    if not profile_path:
-        raise CookieError("Cannot find default Firefox profile")
-
-    cookies_sqlite = os.path.join(profile_path, "cookies.sqlite")
-    if not os.path.exists(cookies_sqlite):
-        raise CookieError("%s doesn't exist." % cookies_sqlite)
-
-    return get_cookies_from_sqlite_xulrunner(host, cookies_sqlite, "Firefox")
-
-def get_bugzilla_cookies_galeon(host):
-    cookies_sqlite = os.path.expanduser('~/.galeon/mozilla/galeon/cookies.sqlite')
-    if not os.path.exists(cookies_sqlite):
-        raise CookieError("%s doesn't exist." % cookies_sqlite)
-
-    return get_cookies_from_sqlite_xulrunner(host, cookies_sqlite, "Galeon")
-
-def get_bugzilla_cookies_epy(host):
-    # epiphany-webkit migrated the cookie db to a different location, but the
-    # format is the same
-    profile_dir = os.path.expanduser('~/.gnome2/epiphany')
-    cookies_sqlite = os.path.join(profile_dir, "cookies.sqlite")
-    if not os.path.exists(cookies_sqlite):
-        # try the old location
-        cookies_sqlite = os.path.join(profile_dir, "mozilla/epiphany/cookies.sqlite")
-
-    if not os.path.exists(cookies_sqlite):
-        raise CookieError("%s doesn't exist" % cookies_sqlite)
-
-    return get_cookies_from_sqlite_xulrunner(host, cookies_sqlite, "Epiphany")
-
-# Shared for Chromium and Google Chrome
-def get_bugzilla_cookies_chr(host, browser, config_dir):
-    config_dir = os.path.expanduser(config_dir)
-    cookies_sqlite = os.path.join(config_dir, "Cookies")
-    if not os.path.exists(cookies_sqlite):
-        raise CookieError("%s doesn't exist" % cookies_sqlite)
-    return get_cookies_from_sqlite(host, cookies_sqlite, browser,
-                                   "select name,value,path,expires_utc from cookies where host_key = :host",
-                                   chromium_time=True)
-
-def get_bugzilla_cookies_chromium(host):
-    return get_bugzilla_cookies_chr(host,
-                                    "Chromium",
-                                    '~/.config/chromium/Default')
-
-def get_bugzilla_cookies_google_chrome(host):
-    return get_bugzilla_cookies_chr(host,
-                                    "Google Chrome",
-                                    '~/.config/google-chrome/Default')
-
-def get_bugzilla_cookies_manual(host):
-    tracker = get_tracker()
-    config = get_config(tracker)
-    for p in 'bugzilla-login', 'bugzilla-logincookie':
-        if p not in config:
-            raise CookieError("config `bz-tracker.%s.%s` not found" % (tracker, p))
-    return {
-        'Bugzilla_login': config['bugzilla-login'],
-        'Bugzilla_logincookie': config['bugzilla-logincookie'],
-    }
-
-browsers = { 'firefox3'     : get_bugzilla_cookies_ff3,
-             'epiphany'     : get_bugzilla_cookies_epy,
-             'galeon'       : get_bugzilla_cookies_galeon,
-             'chromium'     : get_bugzilla_cookies_chromium,
-             'google-chrome': get_bugzilla_cookies_google_chrome,
-             'manual'       : get_bugzilla_cookies_manual }
-
-def browser_list():
-    return ", ".join(sorted(browsers.keys()))
-
-def get_bugzilla_cookies(host):
-    browser = get_browser()
-    if browser in browsers:
-        do_get_cookies = browsers[browser]
-    else:
-        die('Unsupported browser %s (we only support %s)' % (browser, browser_list()))
-
-    try:
-        return do_get_cookies(host)
-    except CookieError, e:
-        die("""Error getting login cookie from browser:
-   %s
-
-Configured browser: %s (change with 'git config --global bz.browser <value>')
-Possible browsers: %s""" %
-            (str(e), browser, browser_list()))
 
 # Based on http://code.activestate.com/recipes/146306/ - Wade Leftwich
 def encode_multipart_formdata(fields, files=None):
@@ -954,11 +725,8 @@ class BugServer(object):
         self.auth_user = auth_user
         self.auth_password = auth_password
 
-        self.cookies = get_bugzilla_cookies(host)
-
     def get_cookie_string(self):
-        return ("Bugzilla_login=%s; Bugzilla_logincookie=%s" %
-                (self.cookies['Bugzilla_login'], self.cookies['Bugzilla_logincookie']))
+        die('unimplemented')
 
     def send_request(self, method, url, data=None, headers={}):
         headers = dict(headers)

--- a/git-bz
+++ b/git-bz
@@ -374,18 +374,6 @@ def tracker_get_path(tracker):
         return config['path']
     return ""
 
-def tracker_get_auth_user(tracker):
-    config = get_config(tracker)
-    if 'auth-user' in config:
-        return config['auth-user']
-    return None
-
-def tracker_get_auth_password(tracker):
-    config = get_config(tracker)
-    if 'auth-password' in config:
-        return config['auth-password']
-    return None
-
 def get_default_fields(tracker):
     config = get_config(tracker)
 
@@ -408,13 +396,11 @@ class BugParseError(Exception):
 # uniquely identifies a bug on a server, though until we try
 # to load it (and create a Bug) we don't know if it actually exists.
 class BugHandle:
-    def __init__(self, host, path, https, id, auth_user=None, auth_password=None):
+    def __init__(self, host, path, https, id):
         self.host = host
         self.path = path
         self.https = https
         self.id = id
-        self.auth_user = auth_user
-        self.auth_password = auth_password
 
         # ensure that the path to the bugzilla installation is an absolute path
         # so that it will still work even if their config option specifies
@@ -431,9 +417,6 @@ class BugHandle:
                                                  self.path if self.path else "",
                                                  self.id)
 
-    def needs_auth(self):
-        return self.auth_user and self.auth_password
-
     @staticmethod
     def parse(bug_reference):
         parseresult = urlparse.urlsplit (bug_reference)
@@ -443,15 +426,10 @@ class BugHandle:
             if len(parseresult.path) == 0 or parseresult.path[0] != '/' or parseresult.hostname is None:
                 raise BugParseError("Invalid bug reference '%s'" % bug_reference)
 
-            user = parseresult.username
-            password = parseresult.password
-            # if the url did not specify http auth credentials in the form
-            # https://user:password@host.com, check to see whether the config file
-            # specifies any auth credentials for this host
-            if not user:
-                user = tracker_get_auth_user(parseresult.hostname)
-            if not password:
-                password = tracker_get_auth_password(parseresult.hostname)
+            if parseresult.username:
+                print 'Ignoring user name in URL.'
+            if parseresult.password:
+                print 'Ignoring password in URL.'
 
             # strip off everything after the last '/', so '/bugzilla/show_bug.cgi'
             # will simply become '/bugzilla'
@@ -462,9 +440,7 @@ class BugHandle:
                 return BugHandle(host=parseresult.hostname,
                                  path=base_path,
                                  https=parseresult.scheme=="https",
-                                 id=m.group(1),
-                                 auth_user=user,
-                                 auth_password=password)
+                                 id=m.group(1))
 
         colon = bug_reference.find(":")
         if colon > 0:
@@ -480,17 +456,14 @@ class BugHandle:
         host = resolve_host_alias(tracker)
         https = tracker_uses_https(tracker)
         path = tracker_get_path(tracker)
-        auth_user = tracker_get_auth_user(tracker)
-        auth_password = tracker_get_auth_password(tracker)
 
         if not re.match(r"^.*\.[a-zA-Z]{2,}$", host):
             raise BugParseError("'%s' doesn't look like a valid bugzilla host or alias" % host)
 
-        return BugHandle(host=host, path=path, https=https, id=id, auth_user=auth_user, auth_password=auth_password)
+        return BugHandle(host=host, path=path, https=https, id=id)
 
     def get_bug_server(self):
-        return get_bug_server(self.host, self.path, self.https,
-                              self.auth_user, self.auth_password)
+        return get_bug_server(self.host, self.path, self.https)
 
 
     @staticmethod
@@ -665,7 +638,7 @@ class ShimMercurialUI:
 
 
 class BugServer(object):
-    def __init__(self, host, path, https, auth_user=None, auth_password=None):
+    def __init__(self, host, path, https):
         self.bugzilla = "%s://%s%s/" % ("https" if https else "http", host, path)
         self.api_server = '%s/bzapi/' % self.bugzilla.rstrip('/')
         self.ui = ShimMercurialUI()
@@ -710,10 +683,10 @@ class BugServer(object):
 
 servers = {}
 
-def get_bug_server(host, path, https, auth_user, auth_password):
+def get_bug_server(host, path, https):
     identifier = (host, path, https)
     if not identifier in servers:
-        servers[identifier] = BugServer(host, path, https, auth_user, auth_password)
+        servers[identifier] = BugServer(host, path, https)
 
     return servers[identifier]
 
@@ -721,9 +694,7 @@ def tracker_get_bug_server(tracker):
     host = resolve_host_alias(tracker)
     path = tracker_get_path(tracker)
     https = tracker_uses_https(tracker)
-    auth_user = tracker_get_auth_user(tracker)
-    auth_password = tracker_get_auth_password(tracker)
-    return get_bug_server(host, path, https, auth_user, auth_password)
+    return get_bug_server(host, path, https)
 
 def check_for_success(response, response_data, *args):
     die('unimplemented')

--- a/git-bz
+++ b/git-bz
@@ -640,10 +640,6 @@ class BugServer(object):
 
 servers = {}
 
-# Note that if we detect that we are redirecting, we may rewrite the
-# host/https of the server to avoid doing too many redirections, and
-# so the host,https we connect to may be different than what we use
-# to look up the server.
 def get_bug_server(host, path, https, auth_user, auth_password):
     identifier = (host, path, https)
     if not identifier in servers:
@@ -659,29 +655,9 @@ def tracker_get_bug_server(tracker):
     auth_password = tracker_get_auth_password(tracker)
     return get_bug_server(host, path, https, auth_user, auth_password)
 
-# Unfortunately, Bugzilla doesn't set a useful status code for
-# form posts.  Because it's very confusing to claim we succeeded
-# but not, we look for text in the response indicating success,
-# and not text indicating failure.
-#
-# We generally look for specific <title> tags - these have been
-# quite stable across versions, though translations will throw
-# us off.
-#
-# *args are regular expressions to search for in response_data
-# that indicate success. Returns the matched regular expression
-# on success, None otherwise
 def check_for_success(response, response_data, *args):
+    die('unimplemented')
 
-    if response.status != 200:
-        return False
-
-    for pattern in args:
-        m = re.search(pattern, response_data)
-        if m:
-            return m
-
-    return None
 
 class Bug(object):
     def __init__(self, server):

--- a/git-bz
+++ b/git-bz
@@ -64,7 +64,6 @@ default-priority = --
 import base64
 import cPickle as pickle
 from ConfigParser import RawConfigParser, NoOptionError
-import httplib
 from optparse import OptionParser
 import os
 import re
@@ -646,8 +645,6 @@ def die(message):
     print >>sys.stderr, message
     sys.exit(1)
 
-def http_auth_header(user, password):
-    return 'Basic ' + base64.encodestring("%s:%s" % (user, password)).strip()
 
 # Classes for bug handling
 # ========================
@@ -659,26 +656,6 @@ class BugPatch(object):
 class NoXmlRpcError(Exception):
     pass
 
-connections = {}
-
-def get_connection(host, https):
-    identifier = (host, https)
-    if not identifier in connections:
-        if https:
-            connection = httplib.HTTPSConnection(host, 443)
-        else:
-            connection = httplib.HTTPConnection(host, 80)
-
-        connections[identifier] = connection
-
-    return connections[identifier]
-
-def kill_connection(host, https):
-    identifier = (host, https)
-    if identifier in connections:
-        del connections[identifier]
-
-
 class BugServer(object):
     def __init__(self, host, path, https, auth_user=None, auth_password=None):
         self.host = host
@@ -687,100 +664,8 @@ class BugServer(object):
         self.auth_user = auth_user
         self.auth_password = auth_password
 
-    def get_cookie_string(self):
-        die('unimplemented')
-
     def send_request(self, method, url, data=None, headers={}):
-        headers = dict(headers)
-        cookies = self.get_cookie_string()
-        if isinstance(cookies, unicode):
-            cookies = cookies.encode('UTF-8')
-        headers['Cookie'] = cookies
-        headers['User-Agent'] = "git-bz"
-        if self.auth_user and self.auth_password:
-            headers['Authorization'] = http_auth_header(self.auth_user, self.auth_password)
-        if self.path:
-            url = self.path + url
-
-        seen_urls = []
-        retries = 0
-        connection = get_connection(self.host, self.https)
-        while True:
-
-            # BMO seems to generate some "bad status line" exception intermittently.
-            try:
-              connection.request(method, url, data, headers)
-              response = connection.getresponse()
-            except httplib.BadStatusLine:
-              retries = retries + 1
-              print "Got bad status line - retrying..."
-              connection.close()
-              kill_connection(self.host, self.https)
-              time.sleep(2)
-              connection = get_connection(self.host, self.https)
-              continue
-            retries = 0
-
-            seen_urls.append(url)
-
-            # Redirect status codes:
-            #
-            # 301 (Moved Permanently): Redo with the new URL,
-            #   save the new location.
-            # 303 (See Other): Redo with the method changed to GET/HEAD.
-            # 307 (Temporary Redirect): Redo with the new URL, don't
-            #   save the new location.
-            #
-            # [ For 301/307, you are supposed to ask the user if the
-            #   method isn't GET/HEAD, but we're automating anyways... ]
-            #
-            # 302 (Found): The confusing one, and the one that
-            # Bugzilla uses, both to redirect to http to https and to
-            # redirect attachment.cgi&action=view to a different base URL
-            # for security. Specified like 307, traditionally treated as 301.
-            #
-            # See http://en.wikipedia.org/wiki/HTTP_302
-
-            if response.status in (301, 302, 303, 307):
-                new_url = response.getheader("location")
-                if new_url is None:
-                    die("Redirect received without a location to redirect to")
-                if new_url in seen_urls or len(seen_urls) >= 10:
-                    die("Circular redirect or too many redirects")
-
-                old_split = urlparse.urlsplit(url)
-                new_split = urlparse.urlsplit(new_url)
-
-                new_https = new_split.scheme == 'https'
-
-                if new_split.hostname != self.host or new_https != self.https:
-                    connection = get_connection(new_split.hostname, new_https != self.https)
-
-                    # This is a bit of a hack to avoid keeping on redirecting for every
-                    # request. If the server redirected show_bug.cgi we assume it's
-                    # really saying "hey, the bugzilla instance is really over here".
-                    #
-                    # We can't do this for old.split.path == new_split.path because of
-                    # attachment.cgi, though we alternatively could just exclude
-                    # attachment.cgi here.
-                    if (response.status in (301, 302) and
-                        method == 'GET' and
-                        old_split.path == '/show_bug.cgi' and new_split.path == '/show_bug.cgi'):
-
-                        self.host = new_split.hostname
-                        self.https = new_https
-
-                # We can't treat 302 like 303 because of the use of 302 for http
-                # to https, though the hack above will hopefully get us on https
-                # before we try to POST.
-                if response.status == 303:
-                    if method not in ('GET', 'HEAD'):
-                        method = 'GET'
-
-                # Get the relative component of the new URL
-                url = urlparse.urlunsplit((None, None, new_split.path, new_split.query, new_split.fragment))
-            else:
-                return response
+        die('unimplemented')
 
     def send_post(self, url, fields, files=None):
         die('unimplemented')

--- a/git-bz
+++ b/git-bz
@@ -507,6 +507,11 @@ class BugHandle:
 
         return BugHandle(host=host, path=path, https=https, id=id, auth_user=auth_user, auth_password=auth_password)
 
+    def get_bug_server(self):
+        return get_bug_server(self.host, self.path, self.https,
+                              self.auth_user, self.auth_password)
+
+
     @staticmethod
     def parse_or_die(str):
         try:
@@ -1164,6 +1169,14 @@ def get_bug_server(host, path, https, auth_user, auth_password):
 
     return servers[identifier]
 
+def tracker_get_bug_server(tracker):
+    host = resolve_host_alias(tracker)
+    path = tracker_get_path(tracker)
+    https = tracker_uses_https(tracker)
+    auth_user = tracker_get_auth_user(tracker)
+    auth_password = tracker_get_auth_password(tracker)
+    return get_bug_server(host, path, https, auth_user, auth_password)
+
 # Unfortunately, Bugzilla doesn't set a useful status code for
 # form posts.  Because it's very confusing to claim we succeeded
 # but not, we look for text in the response indicating success,
@@ -1472,7 +1485,7 @@ class Bug(object):
 
     @staticmethod
     def load(bug_reference, attachmentdata=False):
-        server = get_bug_server(bug_reference.host, bug_reference.path, bug_reference.https, bug_reference.auth_user, bug_reference.auth_password)
+        server = bug_reference.get_bug_server()
         bug = Bug(server)
         bug._load(bug_reference.id, attachmentdata)
 
@@ -1480,14 +1493,8 @@ class Bug(object):
 
     @staticmethod
     def create(tracker, product, component, short_desc, comment):
-        host = resolve_host_alias(tracker)
-        https = tracker_uses_https(tracker)
-        path = tracker_get_path(tracker)
-        auth_user = tracker_get_auth_user(tracker)
-        auth_password = tracker_get_auth_password(tracker)
+        server = tracker_get_bug_server(tracker)
         default_fields = get_default_fields(tracker)
-
-        server = get_bug_server(host, path, https, auth_user, auth_password)
         bug = Bug(server)
         bug._create(product, component, short_desc, comment, default_fields)
 
@@ -2444,14 +2451,7 @@ def do_push(*args):
             edit_bug(bug, commits)
 
 def do_components(*args):
-    tracker = get_tracker()
-    host = resolve_host_alias(tracker)
-    https = tracker_uses_https(tracker)
-    path = tracker_get_path(tracker)
-    auth_user = tracker_get_auth_user(tracker)
-    auth_password = tracker_get_auth_password(tracker)
-
-    server = get_bug_server(host, path, https, auth_user, auth_password)
+    server = tracker_get_bug_server(get_tracker())
 
     if len(args) == 1:
         product = args[0]

--- a/git-bz
+++ b/git-bz
@@ -675,31 +675,8 @@ class BugServer(object):
     def product_id(self, product_name):
         die('unimplemented')
 
-    # Query the server for the legal values of the given field; returns an
-    # array, or None if the query failed
-    def _legal_values(self, field):
-        try:
-            response = self.get_xmlrpc_proxy().Bug.legal_values({ 'field': field })
-            cache.set(self.host, 'legal_' + field, response['values'])
-            return response['values']
-        except xmlrpclib.Fault, e:
-            if e.faultCode == -32000: # https://bugzilla.mozilla.org/show_bug.cgi?id=513511
-                return None
-            raise
-        except xmlrpclib.ProtocolError, e:
-            if e.errcode == 500: # older bugzilla versions die this way
-                return None
-            elif e.errcode == 404: # really old bugzilla, no XML-RPC
-                return None
-            raise
-
     def legal_values(self, field):
-        try:
-            return cache.get(self.host, 'legal_' + field)
-        except IndexError:
-            values = self._legal_values(field)
-            cache.set(self.host, 'legal_' + field, values)
-            return values
+        die('unimplemented')
 
 
 servers = {}

--- a/git-bz
+++ b/git-bz
@@ -716,10 +716,10 @@ class Bug(object):
         self.short_desc = None
         self.patches = []
 
-    def _load(self, id, attachmentdata=False):
+    def _load(self, id, attachment_data=False):
         url = "/show_bug.cgi?id=" + id + "&ctype=xml&format=default"
-        if not attachmentdata:
-            url += "&excludefield=attachmentdata"
+        if not attachment_data:
+            url += "&excludefield=attachment_data"
 
         response = self.server.send_request("GET", url)
         if response.status != 200:
@@ -756,7 +756,7 @@ class Bug(object):
                 patch.token = None if token is None else token.text
                 patch.flag_requestees = set(flag.get("requestee") for flag in attachment.findall("flag"))
 
-                if attachmentdata:
+                if attachment_data:
                     data = attachment.find("data").text
                     patch.data = base64.b64decode(data)
                 else:
@@ -969,10 +969,10 @@ class Bug(object):
 
 
     @staticmethod
-    def load(bug_reference, attachmentdata=False):
+    def load(bug_reference, attachment_data=False):
         server = bug_reference.get_bug_server()
         bug = Bug(server)
-        bug._load(bug_reference.id, attachmentdata)
+        bug._load(bug_reference.id, attachment_data)
 
         return bug
 
@@ -1194,7 +1194,7 @@ def requestee_match(requestees):
 
 def do_apply(bug_reference):
     bug = Bug.load(BugHandle.parse_or_die(bug_reference),
-                   attachmentdata=True)
+                   attachment_data=True)
 
     print "Bug %d - %s" % (bug.id, bug.short_desc)
     print

--- a/git-bz
+++ b/git-bz
@@ -717,20 +717,7 @@ class Bug(object):
                 self.patches.append(patch)
 
     def get_attachment_token(self):
-
-        # Bugzilla now requires a separate token from the attachment creation
-        # page to create an attachment. There doesn't appear to be an XML
-        # interface to it, so we scrape away.
-        url = "/attachment.cgi?bugid=" + str(self.id) + "&action=enter"
-        response = self.server.send_request("GET", url)
-        if response.status != 200:
-          return None
-
-        match = re.search(r'name="token" value="([^"]+)',
-                                     response.read())
-        if not match:
-          return None
-        return  match.group(1)
+        die('unimplemented')
 
     def _create_via_xmlrpc(self, product, component, short_desc, comment, default_fields):
         params = dict()

--- a/git-bz
+++ b/git-bz
@@ -1997,41 +1997,9 @@ def do_attach(*args):
 
     attach_commits(bug, commits, edit=global_options.edit)
 
-# Sort the patches in the bug into categories based on a set of Git
-# git commits that we're considering to be newly applied. Matching
-# is done on exact git subject <=> patch description matches.
-def filter_patches(bug, applied_commits):
-    newly_applied_patches = dict() # maps to the commit object where it was applied
-    obsoleted_patches = set()
-    unapplied_patches = set()
-
-    applied_subjects = dict(((commit.subject, commit) for commit in applied_commits))
-    seen_subjects = set()
-
-    # Work backwards so that the latest patch is considered applied, and older
-    # patches with the same subject obsoleted.
-    for patch in reversed(bug.patches):
-        # Previously committted or rejected patches are never a match
-        if patch.status == "committed" or patch.status == "rejected":
-            continue
-
-        if patch.description in seen_subjects:
-            obsoleted_patches.add(patch)
-        elif patch.description in applied_subjects:
-            newly_applied_patches[patch] = applied_subjects[patch.description]
-            seen_subjects.add(patch)
-        else:
-            unapplied_patches.add(patch)
-
-    return newly_applied_patches, obsoleted_patches, unapplied_patches
-
-def edit_bug(bug, applied_commits=None, fix_commits=None):
-    if applied_commits is not None:
-        newly_applied_patches, obsoleted_patches, unapplied_patches = filter_patches(bug, applied_commits)
-        mark_resolved = len(unapplied_patches) == 0 and bug.bug_status != "RESOLVED"
-    else:
-        newly_applied_patches = obsoleted_patches = set()
-        mark_resolved = fix_commits is not None
+def edit_bug(bug, fix_commits=None):
+    newly_applied_patches = obsoleted_patches = set()
+    mark_resolved = fix_commits is not None
 
     template = StringIO()
     template.write("# Bug %d - %s - %s" % (bug.id, bug.short_desc, bug.bug_status))
@@ -2256,8 +2224,6 @@ def extract_and_collate_bugs(commits):
 def do_edit(bug_reference_or_revision_range):
     try:
         handle = BugHandle.parse(bug_reference_or_revision_range)
-        if global_options.pushed:
-            die("--pushed can't be used together with a bug reference")
         if global_options.fix is not None:
             die("--fix requires commits to be specified")
         bug = Bug.load(handle)
@@ -2277,10 +2243,7 @@ def do_edit(bug_reference_or_revision_range):
             commits.reverse()
             for handle, commits in extract_and_collate_bugs(commits):
                 bug = Bug.load(handle)
-                if global_options.pushed:
-                    edit_bug(bug, applied_commits=commits)
-                else:
-                    edit_bug(bug)
+                edit_bug(bug)
 
 PRODUCT_COMPONENT_HELP = """
 
@@ -2530,8 +2493,6 @@ elif command == 'components':
     max_args = 1
 elif command == 'edit':
     parser.set_usage("git bz edit [options] (<bug reference> | <commit> | <revision range>)");
-    parser.add_option("", "--pushed", action="store_true",
-                      help="pre-fill edit form treating the commits as pushed")
     add_add_url_options()
     add_fix_option()
     min_args = max_args = 1
@@ -2572,8 +2533,6 @@ elif command == 'attach':
 elif command == 'components':
     do_components(*args)
 elif command == 'edit':
-    if global_options.pushed:
-        exit
     do_edit(*args)
 elif command == 'file':
     do_file(*args)

--- a/git-bz
+++ b/git-bz
@@ -59,11 +59,15 @@ https = true
 default-priority = --
 """
 
+CONFIG_CACHE_FILENAME = ".gitbz.ini.cache"
+
+
 ################################################################################
 
 import base64
 import bz
 import bzauth
+import bzexport
 import getpass
 import mercurial # for mercurial.error.Abort
 from optparse import OptionParser
@@ -664,6 +668,12 @@ class BugServer(object):
             print 'Error:', e
             exit(-1)
 
+    def flag_type_id(self, bug, flag_name):
+        assert not bug.product is None
+        assert not bug.component is None
+        return bzexport.flag_type_id(self.ui, self.api_server, CONFIG_CACHE_FILENAME,
+                                     flag_name, bug.product, bug.component)
+
     def get_attachments(self, bugid, attachment_data=False):
         try:
             request = 'bug/%s/attachment' % bugid
@@ -720,6 +730,12 @@ class BugServer(object):
 
     def update_bug(self, bug_id, changes):
         bz.update_bug(self.auth, bug_id, changes)
+
+    def validate_users(self, requestee_list, flag_name):
+        valid_users = bzexport.validate_users(self.ui, self.api_server, self.auth,
+                                              requestee_list, bzexport.multi_user_prompt,
+                                              flag_name + 'er')
+        return bzexport.select_users(valid_users, requestee_list)
 
     def send_post(self, url, fields, files=None):
         die('unimplemented')
@@ -787,9 +803,6 @@ class Bug(object):
             if a["is_obsolete"]:
                 continue
             self.patches.append(BugAttachment(a))
-
-    def get_attachment_token(self):
-        die('unimplemented')
 
     def _create_via_xmlrpc(self, product, component, short_desc, comment, default_fields):
         params = dict()
@@ -864,77 +877,46 @@ class Bug(object):
         print self.get_url()
 
     def create_patch(self, description, comment, filename, data, obsoletes=[], patch_flags={}):
-        fields = {}
-        fields['bugid'] = str(self.id)
-        token = self.get_attachment_token()
-        if token:
-          fields['token'] = token
-        fields['action'] = 'insert'
-        fields['ispatch'] = '1'
-        fields['description'] = description
+        o = {
+            'ids': [self.id],
+            'summary': description,
+            'file_name': filename,
+            'data': base64.b64encode(data),
+            'encoding': 'base64',
+            'content_type': 'text/plain',
+            'is_patch': True,
+            'flags': [],
+        }
+
         if comment:
-            fields['comment'] = comment
-        if obsoletes:
-            # this will produce multiple parts in the encoded data with the
-            # name 'obsolete' for each item in the list
-            fields['obsolete'] = map(str, obsoletes)
+            o['comment'] = comment
 
-        # Support for flagging for review/superreview/feedback/ui-review. I have
-        # no idea if this works on installations other than
-        # bugzilla.mozilla.org. These flag numbers are specified at
-        # https://api-dev.bugzilla.mozilla.org/latest/configuration.
-        # Note that the Firefox component for some reason uses a review flag with
-        # ID 748.  We submit both at the same time, and the server picks the one
-        # that applies to the component.
-        review_flag = 4
-        firefox_review_flag = 748
-        superreview_flag = 5
-        feedback_flag = 607
-        ui_review_flag = 203
-        die('flag code not updated for the new combined format')
-        if review:
-            if review[0] == ':me+':
-                fields['flag_type-%d' % review_flag] = '+'
-                fields['flag_type-%d' % firefox_review_flag] = '+'
-            else:
-                fields['flag_type-%d' % review_flag] = '?'
-                fields['flag_type-%d' % firefox_review_flag] = '?'
-                fields['requestee_type-%d' % review_flag] = ",".join(review)
-                fields['requestee_type-%d' % firefox_review_flag] = ",".join(review)
-        if superreview:
-            if superreview[0] == ':me+':
-                fields['flag_type-%d' % superreview_flag] = '+'
-            else:
-                fields['flag_type-%d' % superreview_flag] = '?'
-                fields['requestee_type-%d' % superreview_flag] = ",".join(superreview)
-        if feedback:
-            if feedback[0] == ':me+':
-                fields['flag_type-%d' % feedback_flag] = '+'
-            else:
-                fields['flag_type-%d' % feedback_flag] = '?'
-                fields['requestee_type-%d' % feedback_flag] = ",".join(feedback)
-        if ui_review:
-            if ui_review[0] == ':me+':
-                fields['flag_type-%d' % ui_review_flag] = '+'
-            else:
-                fields['flag_type-%d' % ui_review_flag] = '?'
-                fields['requestee_type-%d' % ui_review_flag] = ",".join(ui_review)
+        for flag_name, flag_values in patch_flags.iteritems():
+            requestee_list = self.server.validate_users(flag_values.requestees, flag_name)
+            if requestee_list is None:
+                die('Invalid reviewer(s).')
 
-        files = { 'data': (filename, 'text/plain; charset=UTF-8', data) }
+            flag_id = self.server.flag_type_id(self, flag_name)
 
-        response = self.server.send_post("/attachment.cgi", fields, files)
-        response_data = response.read()
-        if not check_for_success(response, response_data,
-                                 # Older bugzilla's used this for successful attachments
-                                 r"<title>\s*Changes\s+Submitted",
-                                 # Newer bugzilla's, use, instead:
-                                 r"<title>\s*Attachment\s+\d+\s+added"):
-            response_match = re.search("<title>([^<]+)</title>", response_data)
-            if response_match:
-                print 'Error response from bugzilla:', response_match.group(1)
-            else:
-                print 'Error response from bugzilla.'
-            die ("Failed to attach patch to bug %d, status=%d" % (self.id, response.status))
+            if not flag_values.status is None:
+                o['flags'].append({
+                    'name': flag_name,
+                    'type_id': flag_id,
+                    'status': flag_values.status,
+                })
+
+            for requestee in requestee_list:
+                o['flags'].append({
+                    'name': flag_name,
+                    'type_id': flag_id,
+                    'status': '?',
+                    'requestee': requestee,
+                })
+
+        self.server.auth.rest_request('POST', 'bug/%s/attachment' % self.id, data=o)
+
+        # It would be better if we could do this in the same request.
+        self.server.obsolete_attachments_by_id(obsoletes)
 
         print "Attached %s" % filename
 

--- a/git-bz
+++ b/git-bz
@@ -62,8 +62,6 @@ default-priority = --
 ################################################################################
 
 import base64
-import cPickle as pickle
-from ConfigParser import RawConfigParser, NoOptionError
 from optparse import OptionParser
 import os
 import re
@@ -72,7 +70,6 @@ from StringIO import StringIO
 from subprocess import Popen, CalledProcessError, PIPE
 import sys
 import tempfile
-import time
 import urlparse
 import xmlrpclib
 from xml.etree.cElementTree import ElementTree
@@ -507,44 +504,6 @@ class BugHandle:
         return ((self.host, self.https, self.id) ==
                 (other.host, other.https, other.id))
 
-
-# Cache of constant-responses per bugzilla server
-# ===============================================
-
-CACHE_EXPIRY_TIME = 3600 * 24 # one day
-
-class Cache(object):
-    def __init__(self):
-        self.cfp = None
-
-    def __ensure(self, host):
-        if self.cfp == None:
-            self.cfp = RawConfigParser()
-            self.cfp.read(os.path.expanduser("~/.git-bz-cache"))
-
-        if self.cfp.has_section(host):
-            if time.time() > self.cfp.getfloat(host, "expires"):
-                self.cfp.remove_section(host)
-
-        if not self.cfp.has_section(host):
-            self.cfp.add_section(host)
-            self.cfp.set(host, "expires", time.time() + CACHE_EXPIRY_TIME)
-
-    def get(self, host, key):
-        self.__ensure(host)
-        try:
-            return pickle.loads(self.cfp.get(host, key))
-        except NoOptionError:
-            raise IndexError()
-
-    def set(self, host, key, value):
-        self.__ensure(host)
-        self.cfp.set(host, key, pickle.dumps(value))
-        f = open(os.path.expanduser("~/.git-bz-cache"), "w")
-        self.cfp.write(f)
-        f.close()
-
-cache = Cache()
 
 # General Utility Functions
 # =========================

--- a/git-bz
+++ b/git-bz
@@ -591,10 +591,6 @@ class BugPatch(object):
         self.attach_id = attach_id
 
 
-class NoXmlRpcError(Exception):
-    pass
-
-
 class ShimMercurialUI:
     def config(self, key1, key2, default=None):
         if key1 != 'bugzilla':
@@ -668,6 +664,10 @@ class BugServer(object):
             print 'Error:', e
             exit(-1)
 
+    def create_bug(self, bug_fields):
+        response = self.auth.rest_request('POST', 'bug', data=bug_fields)
+        return response['id']
+
     def flag_type_id(self, bug, flag_name):
         assert not bug.product is None
         assert not bug.component is None
@@ -737,9 +737,6 @@ class BugServer(object):
                                               flag_name + 'er')
         return bzexport.select_users(valid_users, requestee_list)
 
-    def send_post(self, url, fields, files=None):
-        die('unimplemented')
-
 
 servers = {}
 
@@ -755,9 +752,6 @@ def tracker_get_bug_server(tracker):
     path = tracker_get_path(tracker)
     https = tracker_uses_https(tracker)
     return get_bug_server(host, path, https)
-
-def check_for_success(response, response_data, *args):
-    die('unimplemented')
 
 
 class BugAttachment:
@@ -803,78 +797,6 @@ class Bug(object):
             if a["is_obsolete"]:
                 continue
             self.patches.append(BugAttachment(a))
-
-    def _create_via_xmlrpc(self, product, component, short_desc, comment, default_fields):
-        params = dict()
-        params['product'] = product
-        params['component'] = component
-        params['summary'] = short_desc
-        params['description'] = comment
-        for (field, value) in default_fields.iteritems():
-            params[field] = value
-
-        try:
-            response = self.server.get_xmlrpc_proxy().Bug.create(params)
-            self.id = response['id']
-        except xmlrpclib.Fault, e:
-            die(e.faultString)
-        except xmlrpclib.ProtocolError, e:
-            if e.errcode == 404:
-                raise NoXmlRpcError(e.errmsg)
-            else:
-                print >>sys.stderr, "Problem filing bug via XML-RPC: %s (%d)\n" % (e.errmsg, e.errcode)
-                print >>sys.stderr, "falling back to form post\n"
-                raise NoXmlRpcError("Communication error")
-
-    def _create_with_form(self, product, component, short_desc, comment, default_fields):
-        fields = dict()
-        fields['product'] = product
-        fields['component'] = component
-        fields['short_desc'] = short_desc
-        fields['comment'] = comment
-
-        # post_bug.cgi wants some names that are less congenial than the names
-        # expected in XML-RPC.
-        for (field, value) in default_fields.iteritems():
-            if field == 'severity':
-                field = 'bug_severity'
-            elif field == 'platform':
-                field = 'rep_platform'
-            fields[field] = value
-
-        # Priority values vary wildly between different servers because the stock
-        # Bugzilla uses the awkward P1/../P5. It will be defaulted on the XML-RPC
-        # code path, but we need to take a wild guess here.
-        if not 'priority' in fields:
-            fields['priority'] = 'P5'
-        # Legal severity values are much more standardized, but not specifying it
-        # in the XML-RPC code path allows the server default to win. We need to
-        # specify something here.
-        if not 'severity' in fields:
-            fields['bug_severity'] = 'normal'
-        # Required, but a configured default doesn't make any sense
-        if not 'bug_file_loc' in fields:
-            fields['bug_file_loc'] = ''
-
-        response = self.server.send_post("/post_bug.cgi", fields)
-        response_data = response.read()
-        m = check_for_success(response, response_data,
-                              r"<title>\s*Bug\s+([0-9]+)")
-        if not m:
-            print response_data
-            die("Failed to create bug, status=%d" % response.status)
-
-        self.id = int(m.group(1))
-
-    def _create(self, product, component, short_desc, comment, default_fields):
-        try:
-            self._create_via_xmlrpc(product, component, short_desc, comment, default_fields)
-        except NoXmlRpcError:
-            self._create_with_form(product, component, short_desc, comment, default_fields)
-
-        print "Successfully created"
-        print "Bug %d - %s" % (self.id, short_desc)
-        print self.get_url()
 
     def create_patch(self, description, comment, filename, data, obsoletes=[], patch_flags={}):
         o = {
@@ -935,13 +857,51 @@ class Bug(object):
         return bug
 
     @staticmethod
-    def create(tracker, product, component, short_desc, comment):
+    def create(tracker, product, component, summary, description):
         server = tracker_get_bug_server(tracker)
         default_fields = get_default_fields(tracker)
+
+        # Create the bug in Bugzilla.
+        bug_fields = {}
+        for k, v in default_fields.iteritems():
+            bug_fields[k] = v
+
+        bug_fields['product'] = product
+        bug_fields['component'] = component
+        bug_fields['summary'] = summary
+        bug_fields['description'] = description
+
+        bug_id = server.create_bug(bug_fields)
+
+        print "Successfully created"
+
+        # Create a Bug object for the bug we just created in Bugzilla.
+        # We fill this in using the information we used to create the
+        # bug rather than query the server because it is faster.
         bug = Bug(server)
-        bug._create(product, component, short_desc, comment, default_fields)
+        bug.id = bug_id
+        bug.product = product
+        bug.component = component
+        bug.short_desc = summary.rstrip()
+
+        # bug.bug_status and bug.resolution are not set. We can't tell
+        # if bug_status is UNCONFIRMED or NEW. Hopefully neither will
+        # be needed.
+
+        if False:
+            # Debugging check that we are setting values that match the server.
+            bug2 = Bug(server)
+            bug2._load(str(bug_id))
+            assert bug.id == bug2.id
+            assert bug.product == bug2.product
+            assert bug.component == bug2.component
+            assert bug.short_desc == bug2.short_desc
+
+        print "Bug %d - %s" % (bug.id, summary)
+        print bug.get_url()
 
         return bug
+
 
 # The Commands
 # =============

--- a/git-bz
+++ b/git-bz
@@ -62,7 +62,9 @@ default-priority = --
 ################################################################################
 
 import base64
+import bzauth
 import getpass
+import mercurial # for mercurial.error.Abort
 from optparse import OptionParser
 import os
 import re
@@ -664,11 +666,31 @@ class ShimMercurialUI:
 
 class BugServer(object):
     def __init__(self, host, path, https, auth_user=None, auth_password=None):
-        self.host = host
-        self.path = path
-        self.https = https
-        self.auth_user = auth_user
-        self.auth_password = auth_password
+        self.bugzilla = "%s://%s%s/" % ("https" if https else "http", host, path)
+        self.api_server = '%s/bzapi/' % self.bugzilla.rstrip('/')
+        self.ui = ShimMercurialUI()
+
+        # Ideally, have a config option to stop the message spam for people
+        # who prefer to enter things manually.
+        if not self.ui.config('bugzilla', 'username'):
+            print 'Your bugzilla username is not specified in your git config.'
+            print 'Set it by running:'
+            print '  git config --global bz.username <your username>'
+            print
+        if not self.ui.config('bugzilla', 'apikey'):
+            print 'No bugzilla API key is specified in your git config. This is the'
+            print 'preferred means of authentication, and other methods may break at'
+            print 'any time. An API key can be obtained here:'
+            print '  https://bugzilla.mozilla.org/userprefs.cgi?tab=apikey'
+            print 'Once obtained, set the API key by running:'
+            print '  git config --global bz.apikey <your bugzilla API key>'
+            print
+
+        try:
+            self.auth = bzauth.get_auth(self.ui, self.bugzilla, None)
+        except mercurial.error.Abort, e:
+            print 'Error:', e
+            exit(-1)
 
     def send_request(self, method, url, data=None, headers={}):
         die('unimplemented')
@@ -965,9 +987,8 @@ class Bug(object):
                                                                           response.status))
 
     def get_url(self):
-        return "%s://%s/show_bug.cgi?id=%d" % ("https" if self.server.https else "http",
-                                               self.server.host,
-                                               self.id)
+        return "%sshow_bug.cgi?id=%d" % (self.server.bugzilla, self.id)
+
 
     @staticmethod
     def load(bug_reference, attachmentdata=False):

--- a/mozhg/__init__.py
+++ b/mozhg/__init__.py
@@ -1,0 +1,1 @@
+# Dummy file so that this is treated as a package to mirror the setup in the version-control-tools repository.

--- a/mozhg/auth.py
+++ b/mozhg/auth.py
@@ -1,0 +1,282 @@
+# This software may be used and distributed according to the terms of the
+# GNU General Public License version 2 or any later version.
+
+"""Shared Mercurial code related to authentication."""
+
+import os
+import platform
+import shutil
+import tempfile
+import urlparse
+
+from mercurial import config, util
+from mercurial.i18n import _
+
+
+class BugzillaAuth(object):
+    """Holds Bugzilla authentication credentials."""
+
+    def __init__(self, userid=None, cookie=None, username=None, password=None,
+                 apikey=None):
+        if apikey:
+            self._type = 'apikey'
+        elif userid:
+            self._type = 'cookie'
+        else:
+            self._type = 'explicit'
+
+        self.userid = userid
+        self.cookie = cookie
+        self.username = username
+        self.password = password
+        self.apikey = apikey
+
+
+def getbugzillaauth(ui, require=False, profile=None):
+    """Obtain Bugzilla authentication credentials from any possible source.
+
+    This returns a BugzillaAuth instance on success or None on failure.
+
+    If ``require`` is True, we abort if Bugzilla credentials could not be
+    found.
+
+    If ``profile`` is defined, we will only consult the profile having this
+    name. The default behavior is to examine all available profiles.
+
+    The order of preference for Bugzilla credentials is as follows:
+
+      1) bugzilla.username and bugzilla.apikey from hgrc
+      2) bugzilla.userid and bugzilla.cookie from hgrc
+      3) bugzilla.username and bugzilla.password from hgrc
+      4) login cookies from Firefox profiles
+      5) prompt the user
+
+    The ``bugzilla.firefoxprofile`` option is interpreted as a list of Firefox
+    profiles from which data should be read. This overrides the default sort
+    order.
+    """
+
+    username = ui.config('bugzilla', 'username')
+    apikey = ui.config('bugzilla', 'apikey')
+    password = ui.config('bugzilla', 'password')
+    userid = ui.config('bugzilla', 'userid')
+    cookie = ui.config('bugzilla', 'cookie')
+    profileorder = ui.configlist('bugzilla', 'firefoxprofile', [])
+
+    if username and apikey:
+        return BugzillaAuth(username=username, apikey=apikey)
+
+    if userid and cookie:
+        return BugzillaAuth(userid=userid, cookie=cookie)
+
+    if username and password:
+        return BugzillaAuth(username=username, password=password)
+
+    ui.debug('searching for Bugzilla cookies in Firefox profile\n')
+    url = ui.config('bugzilla', 'url', 'https://bugzilla.mozilla.org/')
+    profilesdir = find_profiles_path()
+    profiles = get_profiles(profilesdir)
+
+    # If the list of profiles is explicitly defined, filter out unknown
+    # profiles and sort by order.
+    if profileorder:
+        profiles = [p for p in profiles if p['name'] in profileorder]
+        profiles = sorted(profiles, key=lambda p: profileorder.index(p['name']))
+
+    for p in profiles:
+        if profile and p['name'] != profile:
+            continue
+
+        try:
+            userid, cookie = get_bugzilla_login_cookie_from_profile(p['path'], url)
+
+            if userid and cookie:
+                return BugzillaAuth(userid=userid, cookie=cookie)
+        except NoSQLiteError:
+            ui.warn('SQLite unavailable. Unable to look for Bugzilla cookie.\n')
+            break
+
+    if not username:
+        username = ui.prompt(_('Bugzilla username:'), None)
+
+    if not password:
+        password = ui.getpass(_('Bugzilla password: '), None)
+
+    if username and password:
+        return BugzillaAuth(username=username, password=password)
+
+    if require:
+        raise util.Abort(_('unable to obtain Bugzilla authentication.'))
+
+    return None
+
+def find_profiles_path():
+    """Find the path containing Firefox profiles.
+
+    The location of Firefox profiles is OS dependent. This function handles the
+    differences.
+    """
+    path = None
+    if platform.system() == 'Darwin':
+        from Carbon import Folder, Folders
+        pathref = Folder.FSFindFolder(Folders.kUserDomain,
+                                      Folders.kApplicationSupportFolderType,
+                                      Folders.kDontCreateFolder)
+        basepath = pathref.FSRefMakePath()
+        path = os.path.join(basepath, 'Firefox')
+    elif platform.system() == 'Windows':
+        # From http://msdn.microsoft.com/en-us/library/windows/desktop/bb762494%28v=vs.85%29.aspx
+        CSIDL_APPDATA = 26
+        path = win_get_folder_path(CSIDL_APPDATA)
+        if path:
+            path = os.path.join(path, 'Mozilla', 'Firefox')
+    else:
+        # Assume POSIX
+        # Pretty simple in comparison, eh?
+        path = os.path.expanduser('~/.mozilla/firefox')
+
+    # This is a backdoor to facilitate testing, since find_profiles_path()
+    # doesn't need to be run-time configurable.
+    path = os.environ.get('FIREFOX_PROFILES_DIR', path)
+
+    return path
+
+def get_profiles(profilesdir):
+    """Obtain information about available Firefox profiles.
+
+    The Firefox profiles from the specified path will be loaded. A list of
+    dicts describing each profile will be returned. The list is sorted
+    according to profile preference. The default profile is always first.
+    """
+    profileini = os.path.join(profilesdir, 'profiles.ini')
+    if not os.path.exists(profileini):
+        return []
+
+    c = config.config()
+    c.read(profileini)
+
+    profiles = []
+    for s in c.sections():
+        if not c.get(s, 'Path') or not c.get(s, 'Name'):
+            continue
+
+        name = c.get(s, 'Name')
+        path = c.get(s, 'Path')
+
+        if c.get(s, 'IsRelative') == '1':
+            path = os.path.join(profilesdir, path)
+
+        newest = -1
+        if os.path.exists(path):
+            mtimes = []
+            for p in os.listdir(path):
+                p = os.path.join(path, p)
+                if os.path.isfile(p):
+                    mtimes.append(os.path.getmtime(p))
+
+            # If there are no files, ignore the profile completely.
+            if not mtimes:
+                continue
+
+            newest = max(mtimes)
+
+        p = {
+            'name': name,
+            'path': path,
+            'default': c.get(s, 'Default', False) and True,
+            'mtime': newest,
+        }
+
+        profiles.append(p)
+
+    def compare(a, b):
+        """Sort profile by default first, file mtime second."""
+        if a['default']:
+            return -1
+
+        if a['mtime'] > b['mtime']:
+            return -1
+        elif a['mtime'] < b['mtime']:
+            return 1
+
+        return 0
+
+    return sorted(profiles, cmp=compare)
+
+def win_get_folder_path(folder):
+    import ctypes
+    SHGetFolderPath = ctypes.windll.shell32.SHGetFolderPathW
+    SHGetFolderPath.argtypes = [ctypes.c_void_p,
+                                ctypes.c_int,
+                                ctypes.c_void_p,
+                                ctypes.c_int32,
+                                ctypes.c_wchar_p]
+    path_buf = ctypes.create_unicode_buffer(1024)
+    if SHGetFolderPath(0, folder, 0, 0, path_buf) != 0:
+        return None
+
+    return path_buf.value
+
+
+# Choose the cookie to use based on how much of its path matches the URL.
+# Useful if you happen to have cookies for both
+# https://landfill.bugzilla.org/bzapi_sandbox/ and
+# https://landfill.bugzilla.org/bugzilla-3.6-branch/, for example.
+def matching_path_len(cookie_path, url_path):
+    return len(cookie_path) if url_path.startswith(cookie_path) else 0
+
+
+class NoSQLiteError(Exception):
+    """Raised when SQLite3 is not available."""
+
+def get_bugzilla_login_cookie_from_profile(profile, url):
+    """Given a Firefox profile path, try to find the login cookies for the given bugzilla URL."""
+    try:
+        import sqlite3
+    except:
+        raise NoSQLiteError()
+
+    cookies = os.path.join(profile, 'cookies.sqlite')
+    if not os.path.exists(cookies):
+        return None, None
+
+    host = urlparse.urlparse(url).hostname
+    path = urlparse.urlparse(url).path
+
+    # Firefox locks this file, so if we can't open it (browser is running)
+    # then copy it somewhere else and try to open it.
+    tempdir = None
+    try:
+        tempdir = tempfile.mkdtemp()
+        tempcookies = os.path.join(tempdir, 'cookies.sqlite')
+        shutil.copyfile(cookies, tempcookies)
+        # Firefox uses sqlite's WAL feature, which bumps the sqlite
+        # version number. Older sqlites will refuse to open the db,
+        # but the actual format is the same (just the journalling is different).
+        # Patch the file to give it an older version number so we can open it.
+        with open(tempcookies, 'r+b') as f:
+            f.seek(18, 0)
+            f.write('\x01\x01')
+        conn = sqlite3.connect(tempcookies)
+        logins = conn.execute("select value, path from moz_cookies "
+                              "where name = 'Bugzilla_login' and (host = ? or host = ?)",
+                              (host, "." + host)).fetchall()
+        row = sorted(logins, key=lambda row: -matching_path_len(row[1], path))[0]
+        login = row[0]
+        cookie = conn.execute("select value from moz_cookies "
+                              "where name = 'Bugzilla_logincookie' "
+                              " and (host = ? or host= ?) "
+                              " and path = ?",
+                              (host, "." + host, row[1])).fetchone()[0]
+        conn.close()
+        if isinstance(login, unicode):
+            login = login.encode('utf-8')
+            cookie = cookie.encode('utf-8')
+        return login, cookie
+
+    except IndexError:
+        return None, None
+
+    finally:
+        if tempdir:
+            shutil.rmtree(tempdir)


### PR DESCRIPTION
This is a series of patches that replaces the current git bz backend that uses a combination of XML RPC and direct https interaction with one that uses the new REST API.

The general structure of the code is that there are a number of files I import from bzexport that do the actual interaction with github. Then, in git-bz, there is a class BugServer that provides a wrapper around those functions. The class Bug then provides a per-bug interface to those where appropriate. At the top level, there are a number of do_foo functions that implement the various commands.

The first few patches do some generic refactoring and remove a few commands that seem obsolete. Then a patch copies over code from bzexport that we will call later.

Then there are a number of patches that remove all of the generic networking backend. This should not include any real "application logic". I did this because there is just so much code to remove it was hard to deal with things otherwise. Each patch basically removes one function, and everything that remains that is exclusively called by that function. This leaves the code in a non-functional state, but the points of failure are explicitly marked with "die("unimplemented")" that will exit when run. These are all gone by the end.

Next, I implement a shim for the Mercurial UI object, which the bzexport backend requires. These functions are all simple. One oddity is that I map bugzilla.foo preferences to bz.foo because that is what git bz was doing. (And obviously I look them up in the git config, not the hg config.)

The rest of the patches implement the various commands. They also remove various little function stubs if they are the last user of that function. The documentation of the Bugzilla REST API lives here: http://bugzilla.readthedocs.org/en/latest/api/

There is a brief interlude to change the representation of review etc. flags to a single map rather than an absurd number of lists.