### PR TITLE
Ignore any bug references in a commit past the first one.

### DIFF
--- a/git-bz
+++ b/git-bz
@@ -1539,6 +1539,10 @@ def extract_and_collate_bugs(commits):
     for commit in commits:
         for handle in extract_bugs_from_commit(commit):
             bugs_to_commits.setdefault(handle, []).append(commit)
+            # Only add the first bug from a commit, given that
+            # the standard Mozilla style is to put the actual
+            # bug number of the commit first.
+            break
 
     return bugs_to_commits.iteritems()
 


### PR DESCRIPTION
This fixes the problem where you have a bug at the start of the patch, as with the standard Mozilla style, but also reference another bug in your commit message.

Fixes #23.