### PR TITLE
Escape username when getting user details.

### DIFF
--- a/git-bz
+++ b/git-bz
@@ -693,7 +693,7 @@ class BugServer(object):
 
     def get_user_detail(self, name):
         try:
-            request = 'user?names=%s' % name
+            request = 'user?names=%s' % urllib2.quote(name, safe='~()*!.\'')
             return self.auth.rest_request('GET', request)['users']
         except mercurial.error.Abort, e:
             print 'Error:', e


### PR DESCRIPTION
Fixes #95.

Please let me know if you'd like some Unicode parsing on top of that (something like `urllib2.parse.quote` or `unicode(name).encode('utf-8')`) and/or if you'd like this fix applied to other code locations.

(I don't actually know Python well, so I took inspiration from [here](https://stackoverflow.com/a/6618858)).